### PR TITLE
fix: forward stdout when installing binaries

### DIFF
--- a/src/config/resolveConfig.js
+++ b/src/config/resolveConfig.js
@@ -5,6 +5,7 @@ import readline from 'mz/readline';
 import getCoffeeFilesFromPathFile from './getCoffeeFilesFromPathFile';
 import getCoffeeFilesUnderPath from './getCoffeeFilesUnderPath';
 import CLIError from '../util/CLIError';
+import execLive from '../util/execLive';
 
 /**
  * Resolve the configuration from a number of sources: any number of config
@@ -106,7 +107,8 @@ async function resolveBinary(binaryName) {
         throw new CLIError(`${binaryName} must be installed.`);
       }
       console.log(`Installing ${binaryName} globally...`);
-      console.log((await exec(`npm install -g ${binaryName}`))[0]);
+      await execLive(`npm install -g ${binaryName}`);
+      console.log(`Successfully installed ${binaryName}\n`);
       return binaryName;
     }
   }

--- a/src/util/execLive.js
+++ b/src/util/execLive.js
@@ -1,0 +1,19 @@
+import { spawn } from 'child_process';
+
+/**
+ * Variant of exec that connects stdout, stderr, and stdin, mostly so console
+ * output is shown continuously. As with the mz version of exec, this returns a
+ * promise that resolves when the shell command finishes.
+ */
+export default function execLive(command) {
+  return new Promise((resolve, reject) => {
+    let childProcess = spawn('/bin/sh', ['-c', command], {stdio: 'inherit'});
+    childProcess.on('close', code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject();
+      }
+    });
+  });
+}


### PR DESCRIPTION
This looks a lot better, since it makes it so you can see installation progress,
rather than getting it all at the end.