### PR TITLE
fix: always write "decaffeinate" in lower-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Here's what `convert` does in more detail:
      leaves a TODO comment to fix any remaining style issues.
   6. All post-decaffeinate changes are committed as a third commit.
 
-In all generated commits, "Decaffeinate" is used as the author name (but not the
+In all generated commits, "decaffeinate" is used as the author name (but not the
 email address). This makes it clear to people using `git blame` that the file
 was generated using decaffeinate, and not necessarily authored by the person who
 happened to run the decaffeinate script.

--- a/src/check.js
+++ b/src/check.js
@@ -15,7 +15,7 @@ export default async function check(config) {
 async function printResults(results) {
   let errorResults = results.filter(r => r.error !== null);
   if (errorResults.length === 0) {
-    console.log(`All checks succeeded! Decaffeinate can convert all ${pluralize(results.length, 'file')}.`);
+    console.log(`All checks succeeded! decaffeinate can convert all ${pluralize(results.length, 'file')}.`);
     console.log('Run this command again with the convert command');
   } else {
     console.log(`${pluralize(errorResults.length, 'file')} failed to convert:`);

--- a/src/convert.js
+++ b/src/convert.js
@@ -35,7 +35,7 @@ Re-run with the "check" command for more details.`);
 
   let gitAuthor = await getGitAuthor();
   let renameCommitMsg =
-    `Decaffeinate: Rename ${pluralize(baseFiles.length, 'file')} from .coffee to .js`;
+    `decaffeinate: Rename ${pluralize(baseFiles.length, 'file')} from .coffee to .js`;
   console.log(`Generating the first commit: "${renameCommitMsg}"...`);
   await exec(`git commit -m "${renameCommitMsg}" --author "${gitAuthor}"`);
 
@@ -59,7 +59,7 @@ Re-run with the "check" command for more details.`);
     {runInSeries: true});
 
   let decaffeinateCommitMsg =
-    `Decaffeinate: Convert ${pluralize(baseFiles.length, 'file')} to JS`;
+    `decaffeinate: Convert ${pluralize(baseFiles.length, 'file')} to JS`;
   console.log(`Generating the second commit: ${decaffeinateCommitMsg}...`);
   await exec(`git commit -m "${decaffeinateCommitMsg}" --author "${gitAuthor}"`);
 
@@ -72,7 +72,7 @@ Re-run with the "check" command for more details.`);
     {runInSeries: true});
 
   let postProcessCommitMsg =
-    `Decaffeinate: Run post-processing cleanups on ${pluralize(baseFiles.length, 'file')}`;
+    `decaffeinate: Run post-processing cleanups on ${pluralize(baseFiles.length, 'file')}`;
   console.log(`Generating the third commit: ${postProcessCommitMsg}...`);
   await exec(`git commit -m "${postProcessCommitMsg}" --author "${gitAuthor}"`);
 
@@ -90,7 +90,7 @@ function getBaseFiles(coffeeFiles) {
 
 async function getGitAuthor() {
   let userEmail = (await exec('git config user.email'))[0];
-  return `Decaffeinate <${userEmail}>`;
+  return `decaffeinate <${userEmail}>`;
 }
 
 function makeEslintFixFn(config) {

--- a/test/test.js
+++ b/test/test.js
@@ -111,9 +111,9 @@ describe('convert', () => {
 
       let logStdout = (await exec('git log --pretty="%an <%ae> %s"'))[0];
       assert.equal(logStdout, `\
-Decaffeinate <sample@example.com> Decaffeinate: Run post-processing cleanups on 2 files
-Decaffeinate <sample@example.com> Decaffeinate: Convert 2 files to JS
-Decaffeinate <sample@example.com> Decaffeinate: Rename 2 files from .coffee to .js
+decaffeinate <sample@example.com> decaffeinate: Run post-processing cleanups on 2 files
+decaffeinate <sample@example.com> decaffeinate: Convert 2 files to JS
+decaffeinate <sample@example.com> decaffeinate: Rename 2 files from .coffee to .js
 Sample User <sample@example.com> Initial commit
 `
       );


### PR DESCRIPTION
This is the preferred way of writing it, I believe, so use a lower-case 'd' in
author names, commit messages, and other messages.