### PR TITLE
feat: optionally run jscodeshift scripts after decaffeinate

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,14 @@ Here's what `convert` does in more detail:
      changes as a merge commit rather than squashing the commits together).
   4. It runs decaffeinate on all files and gets rid of the .coffee files, then
      generates a commit.
-  5. It runs `eslint --fix` on all files, which applies some style fixes
+  5. If the `jscodeshiftScripts` config value is specified, it runs
+     [jscodeshift](https://github.com/facebook/jscodeshift) with those scripts
+     in the order specified.
+  6. It runs `eslint --fix` on all files, which applies some style fixes
      according to your lint rules. For any remaining lint failures, it puts a
      comment at the top of the file disabling those specific lint rules and
      leaves a TODO comment to fix any remaining style issues.
-  6. All post-decaffeinate changes are committed as a third commit.
+  7. All post-decaffeinate changes are committed as a third commit.
 
 In all generated commits, "decaffeinate" is used as the author name (but not the
 email address). This makes it clear to people using `git blame` that the file
@@ -115,6 +118,13 @@ The following config keys can be specified:
 The `filesToProcess` setting has highest precedence, then `pathFile`, then
 `searchDirectory`.
 
+### Other configuration
+
+* `jscodeshiftScripts`: an optional array of paths to
+  [jscodeshift](https://github.com/facebook/jscodeshift) scripts to run after
+  decaffeinate. This is useful to automate any cleanups to convert the output of
+  decaffeinate to code matching your JS style.
+
 ### Configuring paths to external tools
 
 Rather than having bulk-decaffeinate automatically discover the relevant
@@ -126,6 +136,7 @@ specify these paths in the config file.
 These keys can be specified:
 
 * `decaffeinatePath`: the path to the decaffeinate binary.
+* `jscodeshiftPath`: the path to the jscodeshift binary.
 * `eslintPath`: the path to the eslint binary.
 
 ## Future plans

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "decaffeinate": "^2.22.1",
     "eslint": "^3.2.2",
     "eslint-plugin-babel": "^3.3.0",
+    "jscodeshift": "^0.3.28",
     "mocha": "^3.0.2",
     "rollup": "^0.34.5",
     "rollup-plugin-babel": "^2.6.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -31,6 +31,9 @@ export default function () {
     .option('--decaffeinate-path [path]',
       `The path to the decaffeinate binary. If none is specified, it will be
         automatically discovered from node_modules and then from the PATH.`)
+    .option('--jscodeshift-path [path]',
+      `The path to the jscodeshift binary. If none is specified, it will be
+        automatically discovered from node_modules and then from the PATH.`)
     .option('--eslint-path [path]',
       `The path to the eslint binary. If none is specified, it will be
         automatically discovered from node_modules and then from the PATH.`)

--- a/test/examples/jscodeshift-test/A.coffee
+++ b/test/examples/jscodeshift-test/A.coffee
@@ -1,0 +1,2 @@
+nameBefore = 3
+notChanged = 4

--- a/test/examples/jscodeshift-test/bulk-decaffeinate.json
+++ b/test/examples/jscodeshift-test/bulk-decaffeinate.json
@@ -1,0 +1,5 @@
+{
+  "jscodeshiftScripts": [
+    "./change-name.js"
+  ]
+}

--- a/test/examples/jscodeshift-test/change-name.js
+++ b/test/examples/jscodeshift-test/change-name.js
@@ -1,0 +1,15 @@
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  return j(file.source)
+    .find(j.Identifier)
+    .replaceWith(
+      p => {
+        if (p.node.name === 'nameBefore') {
+          return j.identifier('nameAfter');
+        } else {
+          return p.node;
+        }
+      }
+    )
+    .toSource();
+}

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,7 @@ let originalCwd = process.cwd();
 async function runCli(args) {
   return (await exec(`"${originalCwd}/bin/bulk-decaffeinate" \
     --decaffeinate-path "${originalCwd}/node_modules/.bin/decaffeinate" \
+    --jscodeshift-path "${originalCwd}/node_modules/.bin/jscodeshift" \
     --eslint-path "${originalCwd}/node_modules/.bin/eslint" \
     ${args}`))[0];
 }
@@ -117,6 +118,24 @@ decaffeinate <sample@example.com> decaffeinate: Rename 2 files from .coffee to .
 Sample User <sample@example.com> Initial commit
 `
       );
+    });
+  });
+
+  it('runs jscodeshift', async function() {
+    await runWithTemplateDir('jscodeshift-test', async function() {
+      await initGitRepo();
+      let decaffeinateStdout = await runCli('convert');
+      assertIncludes(decaffeinateStdout, 'Successfully ran decaffeinate');
+
+      await assertFileContents('./A.js', `\
+/* eslint-disable
+    no-unused-vars,
+*/
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+let nameAfter = 3;
+let notChanged = 4;
+`);
     });
   });
 


### PR DESCRIPTION
A new config setting lets you specify an array of script paths to run once
decaffeinate finishes. Like with decaffeinate and eslint, we prompt to install
jscodeshift if necessary, but we only do this if any paths are actually
specified.