### PR TITLE
fix: fail if there are uncommitted git changes when running convert

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -8,6 +8,8 @@ import execLive from './util/execLive';
 import pluralize from './util/pluralize';
 
 export default async function convert(config) {
+  await assertGitWorktreeClean();
+
   let coffeeFiles = config.filesToProcess;
   let baseFiles = getBaseFiles(coffeeFiles);
 
@@ -97,6 +99,15 @@ Re-run with the "check" command for more details.`);
   await exec(`git commit -m "${postProcessCommitMsg}" --author "${gitAuthor}"`);
 
   console.log(`Successfully ran decaffeinate on ${pluralize(baseFiles.length, 'file')}.`);
+}
+
+async function assertGitWorktreeClean() {
+  let stdout = (await exec('git status --short --untracked-files=no'))[0];
+  if (stdout.length) {
+    throw new CLIError(`\
+You have modifications to your git worktree.
+Please revert or commit them before running convert.`);
+  }
 }
 
 function getBaseFiles(coffeeFiles) {

--- a/test/test.js
+++ b/test/test.js
@@ -188,4 +188,16 @@ console.log(x);
       assertIncludes(stderr, 'The file A.js already exists.');
     });
   });
+
+  it('fails when the git worktree has changes', async function() {
+    await runWithTemplateDir('simple-success', async function() {
+      await initGitRepo();
+      await exec('echo "x = 2" >> A.coffee');
+      let {stderr} = await runCli('convert');
+      assertIncludes(stderr, 'You have modifications to your git worktree.');
+      await exec('git add A.coffee');
+      ({stderr} = await runCli('convert'));
+      assertIncludes(stderr, 'You have modifications to your git worktree.');
+    });
+  });
 });


### PR DESCRIPTION
This avoids the issue where changes could get lumped in with the decaffeinate
changes inadvertently.