### PR TITLE
feat: add a "clean" command that deletes .original.coffee files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ There are currently three commands you can run:
   failed files in the [online decaffeinate repl](http://decaffeinate-project.org/repl/),
   with one browser tab per failed file.
 * `convert` actually converts the files from CofeeScript to JavaScript.
+* `clean` deletes all .original.coffee files in the current directory or any of
+  its subdirectories.
 
 Here's what `convert` does in more detail:
   1. It does a dry run of decaffeinate on all files to make sure there won't be

--- a/src/clean.js
+++ b/src/clean.js
@@ -1,0 +1,15 @@
+import { unlink } from 'mz/fs';
+import getFilesUnderPath from './util/getFilesUnderPath';
+
+export default async function clean() {
+  let filesToDelete = await getFilesUnderPath('.', p => p.endsWith('.original.coffee'));
+  if (filesToDelete.length === 0) {
+    console.log('No .original.coffee files were found.');
+    return;
+  }
+  for (let path of filesToDelete) {
+    console.log(`Deleting ${path}`);
+    await unlink(path);
+  }
+  console.log('Done deleting .original.coffee files.');
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,6 +2,7 @@ import 'babel-polyfill';
 import commander from 'commander';
 
 import check from './check';
+import clean from './clean';
 import resolveConfig from './config/resolveConfig';
 import convert from './convert';
 import CLIError from './util/CLIError';
@@ -19,7 +20,9 @@ export default function () {
       directory are used.
     convert: Run decaffeinate on the specified files and generate git commits
       for the transition.
-    view-errors: Open failures from the most recent run in an online repl.`)
+    view-errors: Open failures from the most recent run in an online repl.
+    clean: Delete all files ending with .original.coffee in the current
+      working directory or any of its subdirectories.`)
     .action(commandArg => command = commandArg)
     .option('-p, --path-file [path]',
       `A file containing the paths of .coffee files to decaffeinate, one
@@ -52,6 +55,8 @@ async function runCommand(command) {
       await convert(config);
     } else if (command === 'view-errors') {
       await viewErrors();
+    } else if (command === 'clean') {
+      await clean();
     } else {
       commander.outputHelp();
     }

--- a/src/config/getCoffeeFilesUnderPath.js
+++ b/src/config/getCoffeeFilesUnderPath.js
@@ -1,24 +1,10 @@
-import { readdir, stat } from 'mz/fs';
-import { join } from 'path';
+import getFilesUnderPath from '../util/getFilesUnderPath';
 
 /**
  * Recursively discover any .coffee files in the current directory, ignoring
  * things like node_modules and .git.
  */
 export default async function getCoffeeFilesUnderPath(dirPath) {
-  let resultFiles = [];
-  let children = await readdir(dirPath);
-  for (let child of children) {
-    if (['node_modules', '.git'].includes(child)) {
-      continue;
-    }
-    let childPath = join(dirPath, child);
-    if ((await stat(childPath)).isDirectory()) {
-      let subdirCoffeeFiles = await getCoffeeFilesUnderPath(childPath);
-      resultFiles.push(...subdirCoffeeFiles);
-    } else if (child.endsWith('.coffee') && !child.endsWith('.original.coffee')) {
-      resultFiles.push(childPath);
-    }
-  }
-  return resultFiles;
+  return await getFilesUnderPath(
+    dirPath, p => p.endsWith('.coffee') && !p.endsWith('.original.coffee'));
 }

--- a/src/util/getFilesUnderPath.js
+++ b/src/util/getFilesUnderPath.js
@@ -1,0 +1,24 @@
+import { readdir, stat } from 'mz/fs';
+import { join } from 'path';
+
+/**
+ * Recursively discover any matching files in the current directory, ignoring
+ * things like node_modules and .git.
+ */
+export default async function getFilesUnderPath(dirPath, pathPredicate) {
+  let resultFiles = [];
+  let children = await readdir(dirPath);
+  for (let child of children) {
+    if (['node_modules', '.git'].includes(child)) {
+      continue;
+    }
+    let childPath = join(dirPath, child);
+    if ((await stat(childPath)).isDirectory()) {
+      let subdirCoffeeFiles = await getFilesUnderPath(childPath, pathPredicate);
+      resultFiles.push(...subdirCoffeeFiles);
+    } else if (pathPredicate(child)) {
+      resultFiles.push(childPath);
+    }
+  }
+  return resultFiles;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ import 'babel-polyfill';
 
 import assert from 'assert';
 import { exec } from 'mz/child_process';
-import { readFile } from 'mz/fs';
+import { exists, readFile } from 'mz/fs';
 
 let originalCwd = process.cwd();
 
@@ -198,6 +198,22 @@ console.log(x);
       await exec('git add A.coffee');
       ({stderr} = await runCli('convert'));
       assertIncludes(stderr, 'You have modifications to your git worktree.');
+    });
+  });
+
+  it('generates backup files that are removed by clean', async function() {
+    await runWithTemplateDir('simple-success', async function() {
+      await initGitRepo();
+      await runCli('convert');
+      assert(
+        await exists('./A.original.coffee'),
+        'Expected a backup file to be created.'
+      );
+      await runCli('clean');
+      assert(
+        !await exists('./A.original.coffee'),
+        'Expected the "clean" command to get rid of the backup file.'
+      );
     });
   });
 });


### PR DESCRIPTION
These backups are usually harmless, but they can cause problems if they get
auto-discovered by the test runner, and it's annoying to have them around once
the conversion is complete. Programmatically deleting files is scary, so I made
the help text make it very clear what it does.