### PR TITLE
feat: add a fix-imports step

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,14 @@ Here's what `convert` does in more detail:
      in the order specified.
   6. If the `mochaEnvFilePattern` config value is specified, it prepends
      `/* eslint-env mocha */` to the top of every test file.
-  7. It runs `eslint --fix` on all files, which applies some style fixes
+  7. If the `fixImportsConfig` config value is specified, it runs a transform
+     that does whole-codebase analysis to fix any import problems that might
+     have been introduced by decaffeinate.
+  8. It runs `eslint --fix` on all files, which applies some style fixes
      according to your lint rules. For any remaining lint failures, it puts a
      comment at the top of the file disabling those specific lint rules and
      leaves a TODO comment to fix any remaining style issues.
-  8. All post-decaffeinate changes are committed as a third commit.
+  9. All post-decaffeinate changes are committed as a third commit.
 
 In all generated commits, "decaffeinate" is used as the author name (but not the
 email address). This makes it clear to people using `git blame` that the file
@@ -135,6 +138,15 @@ The `filesToProcess` setting has highest precedence, then `pathFile`, then
   [jscodeshift](https://github.com/facebook/jscodeshift) scripts to run after
   decaffeinate. This is useful to automate any cleanups to convert the output of
   decaffeinate to code matching your JS style.
+* `fixImportsConfig`: an optional object. If present, a whole-codebase pass will
+  be done to fix any incorrect imports involving the converted files. It should
+  be an object with up to two fields:
+  * `searchPath`: a required field specifying a path to a directory containing
+    all JS files in the project.
+  * `absoluteImportPaths`: an optional array of strings, each of which is used
+    as an absolute path starting point when resolving imports. This is necessary
+    if you do any tricks to get absolute-style imports in your project, since
+    the fix-imports script needs to be able to resolve import names to files.
 * `mochaEnvFilePattern`: an optional regular expression string. If specified,
   all generated JavaScript files with a path matching this pattern have the text
   `/* eslint-env mocha */` added to the start. For example, `"^.*-test.js$"`.

--- a/jscodeshift-scripts/fix-imports.js
+++ b/jscodeshift-scripts/fix-imports.js
@@ -1,0 +1,523 @@
+/**
+ * Script that fixes import styles to properly match the export style of the
+ * file being imported. Since decaffeinate doesn't do whole-codebase analysis,
+ * we need to do this as a follow-up step.
+ *
+ * Note that this conversion runs on ALL project files (or, at least, any files
+ * that could import a converted file). In general, it can handle any import
+ * statement, read the exports of the file being imported, and adjust the import
+ * usage to properly use the named/default exports as necessary.
+ *
+ * See the test examples starting with "fix-imports" for lots of examples.
+ *
+ * The script is quite thorough and mostly correct, but it can fail in the case
+ * of variable shadowing, dynamic usages of a default import or an import *
+ * object, or code that depends on the "live binding" behavior of imports, and
+ * likely other subtle cases.
+ *
+ * See https://github.com/decaffeinate/decaffeinate/issues/402 for some more
+ * details on why decaffeinate can't solve this itself.
+ */
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+
+export default function (fileInfo, api, options) {
+  let decodedOptions = JSON.parse(new Buffer(options['encoded-options'], 'base64'));
+  let {convertedFiles, absoluteImportPaths} = decodedOptions;
+  let j = api.jscodeshift;
+  let thisFilePath = path.resolve(fileInfo.path);
+  let root = j(fileInfo.source);
+
+  function convertFile() {
+    if (includes(convertedFiles, thisFilePath)) {
+      return fixImportsForConvertedFile();
+    } else {
+      return fixImportsForOtherFile();
+    }
+  }
+
+  /**
+   * This file was just converted to JS, so ANY import has the potential to be
+   * invalid.
+   */
+  function fixImportsForConvertedFile() {
+    return root
+      .find(j.ImportDeclaration)
+      .replaceWith(fixImportAtPath)
+      .toSource();
+  }
+
+  /**
+   * This file was not just converted to JS, but could potentially import files
+   * that were. Correct any of those imports.
+   */
+  function fixImportsForOtherFile() {
+    return root
+      .find(j.ImportDeclaration)
+      .filter(path => {
+        let importPath = resolveImportPath(thisFilePath, path.node.source.value);
+        return includes(convertedFiles, importPath);
+      })
+      .replaceWith(fixImportAtPath)
+      .toSource();
+  }
+
+  /**
+   * Top-level import-fixing code. We get all relevant information about the
+   * names being imported and the names exported by the other file, and then
+   * produce a set of changes on the import statement, including possibly some
+   * destructure operations after the import.
+   */
+  function fixImportAtPath(path) {
+    let importPath = path.node.source.value;
+    let resolvedPath = resolveImportPath(thisFilePath, importPath);
+    if (resolvedPath === null) {
+      return path.node;
+    }
+    let exportsInfo = getExportsInformation(resolvedPath);
+    let specifierIndex = getSpecifierIndex(path);
+    let memberAccesses = findAllMemberAccesses(specifierIndex);
+    let importManifest = getImportManifest(exportsInfo, memberAccesses);
+
+    // If any sort of property is accessed from the default import, we need it.
+    // Also, the default import might be something like a function where we
+    // imported it and the other module has a default export.
+    let needsDefaultImport =
+      importManifest.defaultImportDirectAccesses.length > 0 ||
+      importManifest.defaultImportObjectAccesses.length > 0 ||
+      (exportsInfo.hasDefaultExport && specifierIndex.defaultImport !== null);
+
+    // If there are object-style accesses of named imports
+    // (e.g. MyModule.myExport), then handle those with a star import. If we
+    // also have direct usages of named exports (e.g. myOtherExport), we'll need
+    // to destructure them from the * import later, but we try to avoid that
+    // when possible.
+    let needsStarImport = importManifest.namedImportObjectAccesses.length > 0;
+
+    let {defaultImportName, starImportName} = resolveImportObjectNames(
+      specifierIndex, needsDefaultImport, needsStarImport,
+      exportsInfo.hasDefaultExport, importPath);
+
+    path.node.specifiers = createImportSpecifiers(
+      defaultImportName, starImportName, specifierIndex, importManifest);
+
+    renameObjectAccesses(defaultImportName, starImportName, importManifest);
+
+    if (importManifest.defaultImportDirectAccesses.length > 0) {
+      insertImportDestructure(
+        path, importManifest.defaultImportDirectAccesses, specifierIndex, defaultImportName);
+    }
+    // If we don't have a star import, named imports were done in the import statement.
+    // Otherwise, we need to destructure from the star import to get direct names from it.
+    if (starImportName !== null && importManifest.namedImportDirectAccesses.length > 0) {
+      insertImportDestructure(path, importManifest.namedImportDirectAccesses, specifierIndex, starImportName);
+    }
+    return path.node;
+  }
+
+  /**
+   * Turn an import string into an absolute path to a JS file.
+   */
+  function resolveImportPath(importingFilePath, importPath) {
+    if (!importPath.endsWith('.js')) {
+      importPath += '.js';
+    }
+    let currentDir = path.dirname(importingFilePath);
+    let relativePath = path.resolve(currentDir, importPath);
+    if (existsSync(relativePath)) {
+      return relativePath;
+    }
+    for (let absoluteImportPath of absoluteImportPaths) {
+      let absolutePath = path.resolve(absoluteImportPath, importPath);
+      if (existsSync(absolutePath)) {
+        return absolutePath;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Determine the names of all exports provided by a module and whether or not
+   * it has a default export.
+   */
+  function getExportsInformation(filePath) {
+    let source = readFileSync(filePath).toString();
+    let root = j(source);
+
+    let hasDefaultExport = false;
+    let namedExports = [];
+    root.find(j.ExportNamedDeclaration)
+      .forEach(p => {
+        for (let specifier of p.node.specifiers) {
+          namedExports.push(specifier.exported.name);
+        }
+        if (p.node.declaration) {
+          if (p.node.declaration.declarations) {
+            for (let declaration of p.node.declaration.declarations) {
+              namedExports.push(declaration.id.name);
+            }
+          }
+          if (p.node.declaration.id) {
+            namedExports.push(p.node.declaration.id);
+          }
+        }
+      });
+
+    root.find(j.ExportDefaultDeclaration)
+      .forEach(() => {hasDefaultExport = true;});
+
+    root.find(j.ExportAllDeclaration)
+      .forEach(p => {
+        let otherFilePath = resolveImportPath(filePath, p.node.source.value);
+        if (otherFilePath === null) {
+          return;
+        }
+        let otherFileExports = getExportsInformation(otherFilePath);
+        for (let namedExport of otherFileExports.namedExports) {
+          namedExports.push(namedExport);
+        }
+      });
+    return {hasDefaultExport, namedExports};
+  }
+
+  /**
+   * Return an object that makes it more convenient to look up import specifiers
+   * rather than having to loop through the array.
+   */
+  function getSpecifierIndex(path) {
+    let defaultImport = null;
+    let starImport = null;
+    let namedImportsByImportedName = new Map();
+    for (let specifier of path.node.specifiers) {
+      if (specifier.type === 'ImportDefaultSpecifier') {
+        defaultImport = specifier;
+      } else if (specifier.type === 'ImportNamespaceSpecifier') {
+        starImport = specifier;
+      } else if (specifier.type === 'ImportSpecifier') {
+        namedImportsByImportedName.set(specifier.imported.name, specifier);
+      }
+    }
+    return {
+      defaultImport,
+      starImport,
+      namedImportsByImportedName,
+    };
+  }
+
+  /**
+   * Figure out what values are accessed from this import, including attributes
+   * pulled off of the default or star imports.
+   */
+  function findAllMemberAccesses(specifierIndex) {
+    let defaultImportAccesses = [];
+    let starImportAccesses = [];
+    let directAccesses = [];
+    if (specifierIndex.defaultImport !== null) {
+      let name = specifierIndex.defaultImport.local.name;
+      defaultImportAccesses.push(...getMemberAccessesForName(name));
+    }
+    if (specifierIndex.starImport !== null) {
+      let name = specifierIndex.starImport.local.name;
+      starImportAccesses.push(...getMemberAccessesForName(name));
+    }
+    for (let specifier of specifierIndex.namedImportsByImportedName.values()) {
+      directAccesses.push(specifier.imported.name);
+    }
+    return {
+      defaultImportAccesses,
+      starImportAccesses,
+      directAccesses
+    };
+  }
+
+  /**
+   * Given a name, find all cases in the code where a field is accessed from
+   * that name. For example, if objectName is Foo and the code contains Foo.a,
+   * Foo.b, and Foo.c, return the set {'a', 'b', 'c'}.
+   */
+  function getMemberAccessesForName(objectName) {
+    let membersAccessed = new Set();
+    root
+      .find(j.MemberExpression, {
+        object: {
+          name: objectName
+        }
+      })
+      .forEach(path => {
+        if (path.node.property.type === 'Identifier') {
+          membersAccessed.add(path.node.property.name);
+        }
+      });
+    return membersAccessed;
+  }
+
+  /**
+   * Figure out what types of imports are needed in the resulting code based on
+   * what names are actually used and what names are exported by the other
+   * module.
+   */
+  function getImportManifest(exportsInfo, memberAccesses) {
+    let defaultImportDirectAccesses = [];
+    let defaultImportObjectAccesses = [];
+    let namedImportDirectAccesses = [];
+    let namedImportObjectAccesses = [];
+
+    let exportedNames = new Set(exportsInfo.namedExports);
+    for (let name of memberAccesses.defaultImportAccesses) {
+      if (exportedNames.has(name)) {
+        namedImportObjectAccesses.push(name);
+      } else {
+        defaultImportObjectAccesses.push(name);
+      }
+    }
+    for (let name of memberAccesses.starImportAccesses) {
+      if (exportedNames.has(name)) {
+        namedImportObjectAccesses.push(name);
+      } else {
+        defaultImportObjectAccesses.push(name);
+      }
+    }
+    for (let name of memberAccesses.directAccesses) {
+      if (exportedNames.has(name)) {
+        namedImportDirectAccesses.push(name);
+      } else {
+        defaultImportDirectAccesses.push(name);
+      }
+    }
+    return {
+      defaultImportDirectAccesses,
+      defaultImportObjectAccesses,
+      namedImportDirectAccesses,
+      namedImportObjectAccesses,
+    };
+  }
+
+  /**
+   * Figure out what names to use for the default import and the import *
+   * values, based on the existing names (if any) and which ones we actually
+   * need.
+   */
+  function resolveImportObjectNames(
+      specifierIndex, needsDefaultImport, needsStarImport, hasDefaultExport, importPath) {
+    let existingDefaultImportName =
+      specifierIndex.defaultImport && specifierIndex.defaultImport.local.name;
+    let existingStarImportName =
+      specifierIndex.starImport && specifierIndex.starImport.local.name;
+
+    let defaultImportName = null;
+    let starImportName = null;
+
+    if ((!needsDefaultImport || existingDefaultImportName !== null) &&
+        (!needsStarImport || existingStarImportName !== null)) {
+      // If we already have all the names we need, then no name-generation required!
+      // Just use them.
+      if (needsDefaultImport) {
+        defaultImportName = existingDefaultImportName;
+      }
+      if (needsStarImport) {
+        starImportName = existingStarImportName;
+      }
+    } else if (needsDefaultImport && hasDefaultExport && existingDefaultImportName !== null) {
+      // If we potentially use the default import for anything other than object
+      // accesses, then we prefer to keep the name as-is, so special-case that.
+      defaultImportName = existingDefaultImportName;
+      if (needsStarImport) {
+        starImportName = findFreeName(defaultImportName + 'Exports');
+      }
+    } else if (needsDefaultImport) {
+      // Otherwise, we need to fill in at least one name and there aren't any
+      // specific constraints that we have to follow. Give the default import
+      // naming priority. If we also need a star import, give it a name based
+      // on our default name.
+      if (existingDefaultImportName !== null) {
+        defaultImportName = existingDefaultImportName;
+      } else if (existingStarImportName !== null && !needsStarImport) {
+        defaultImportName = existingStarImportName;
+      } else if (existingStarImportName !== null && needsStarImport) {
+        defaultImportName = findFreeName(existingStarImportName + 'Default');
+      } else {
+        defaultImportName = findFreeName(inferNameFromImportPath(importPath));
+      }
+      if (needsStarImport) {
+        if (existingStarImportName !== null) {
+          starImportName = existingStarImportName;
+        } else {
+          starImportName = findFreeName(defaultImportName + 'Exports');
+        }
+      }
+    } else if (needsStarImport) {
+      // Otherwise, we might need a star import name but no default import name.
+      // Try using the existing name or stealing from the default name if
+      // possible. If not, come up with a new name from the path.
+      if (existingStarImportName !== null) {
+        starImportName = existingStarImportName;
+      } else if (existingDefaultImportName !== null) {
+        starImportName = existingDefaultImportName;
+      } else {
+        starImportName = findFreeName(inferNameFromImportPath(importPath));
+      }
+    }
+
+    return {defaultImportName, starImportName};
+  }
+
+  /**
+   * Guess a nice capitalized camelCase name from a filename on an import. For
+   * example, './util/dashed-name' becomes 'DashedName'.
+   */
+  function inferNameFromImportPath(importPath) {
+    let lastSlashIndex = importPath.lastIndexOf('/');
+    let filename = importPath;
+    if (lastSlashIndex > -1) {
+      filename = filename.substr(lastSlashIndex + 1);
+    }
+    if (filename.endsWith('.js')) {
+      filename = filename.substr(0, filename.length - 3);
+    }
+    return camelCaseName(filename);
+  }
+
+  /**
+   * Convert the given string to a capitalized camelCase name.
+   *
+   * Somewhat based on this discussion:
+   * http://stackoverflow.com/questions/2970525/converting-any-string-into-camel-case
+   */
+  function camelCaseName(name) {
+    return name
+      .replace(/(^|[ \-_])(.)/g, match => match.toUpperCase())
+      .replace(/[ \-_]/g, '');
+  }
+
+  /**
+   * Find a variable name that is unused in the code to avoid name clashes with
+   * existing names.
+   */
+  function findFreeName(desiredName) {
+    if (!isNameTaken(desiredName)) {
+      return desiredName;
+    }
+    for (let i = 1; i < 5000; i++) {
+      let name = `${desiredName}${i}`;
+      if (!isNameTaken(name)) {
+        return name;
+      }
+    }
+    throw new Error('Could not find a suitable name.');
+  }
+
+  function isNameTaken(desiredName) {
+    return root.find(j.Identifier, {name: desiredName}).size() > 0;
+  }
+
+  /**
+   * Create the direct contents of the import statement. This may include a
+   * default import, a star import, and/or a list of named imports. Note that
+   * we are now allowed to have both a star import and named imports, so if we
+   * need both, we do a star import and will destructure it later.
+   */
+  function createImportSpecifiers(
+      defaultImportName, starImportName, specifierIndex, importManifest) {
+    let specifiers = [];
+    if (defaultImportName) {
+      if (specifierIndex.defaultImport !== null) {
+        specifiers.push(specifierIndex.defaultImport);
+      } else {
+        specifiers.push(j.importDefaultSpecifier(j.identifier(defaultImportName)));
+      }
+    }
+    if (starImportName) {
+      if (specifierIndex.starImport !== null) {
+        specifiers.push(specifierIndex.starImport);
+      } else {
+        specifiers.push(j.importNamespaceSpecifier(j.identifier(starImportName)));
+      }
+    }
+    // If we don't have a star import, named imports can go directly in the
+    // import statement. Otherwise we'll need to destructure them from the star
+    // import later.
+    if (!starImportName) {
+      for (let importName of importManifest.namedImportDirectAccesses) {
+        specifiers.push(specifierIndex.namedImportsByImportedName.get(importName));
+      }
+    }
+    return specifiers;
+  }
+
+  /**
+   * Do a rename operation to handle object-style accesses. For example, if we
+   * have the import line `import Foo, * as FooExports from './Foo';` and a line
+   * in the code is `Foo.bar`, but `bar` is a named export on the foo module, we
+   * need to rename the reference in the code to `FooExports.bar`.
+   */
+  function renameObjectAccesses(defaultImportName, starImportName, importManifest) {
+    let defaultImportProperties = new Set(importManifest.defaultImportObjectAccesses);
+    let starImportProperties = new Set(importManifest.namedImportObjectAccesses);
+    root
+      .find(j.MemberExpression)
+      .replaceWith(path => {
+        let {object, property} = path.node;
+        if (object.type !== 'Identifier' ||
+            (object.name !== defaultImportName && object.name !== starImportName) ||
+            property.type !== 'Identifier') {
+          return path.node;
+        }
+        if (defaultImportProperties.has(property.name)) {
+          object.name = defaultImportName;
+        }
+        if (starImportProperties.has(property.name)) {
+          object.name = starImportName;
+        }
+        return path.node;
+      });
+  }
+
+  /**
+   * Create a destructure statement after the import statement. This is a way
+   * to simulate named imports for default imports and star imports.
+   */
+  function insertImportDestructure(path, importNames, specifierIndex, importName) {
+    let destructureFields = importNames.map(
+      importName => {
+        let specifier = specifierIndex.namedImportsByImportedName.get(importName);
+        return {
+          accessName: specifier.imported.name,
+          boundName: specifier.local.name,
+        };
+      }
+    );
+    path.insertAfter(makeDestructureStatement(destructureFields, importName));
+  }
+
+  function makeDestructureStatement(destructureFields, objName) {
+    let properties = destructureFields.map(({accessName, boundName}) => {
+      let property = j.property(
+        'init',
+        j.identifier(accessName),
+        j.identifier(boundName)
+      );
+      if (accessName === boundName) {
+        property.shorthand = true;
+      }
+      return property;
+    });
+    return j.variableDeclaration(
+      'const',
+      [
+        j.variableDeclarator(
+          j.objectPattern(properties),
+          j.identifier(objName)
+        )
+      ]
+    );
+  }
+
+  return convertFile();
+}
+
+/**
+ * Little helper since we don't have Array.prototype.includes.
+ */
+function includes(arr, elem) {
+  return arr.indexOf(elem) > -1;
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "prebuild": "npm run lint",
     "build": "rollup -c",
-    "lint": "eslint src test",
+    "lint": "eslint src test jscodeshift-scripts",
     "pretest": "npm run build",
     "test": "mocha",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
@@ -28,7 +28,8 @@
   "license": "MIT",
   "files": [
     "bin",
-    "dist"
+    "dist",
+    "jscodeshift-scripts"
   ],
   "bugs": {
     "url": "https://github.com/alangpierce/bulk-decaffeinate/issues"

--- a/src/config/resolveConfig.js
+++ b/src/config/resolveConfig.js
@@ -34,6 +34,7 @@ export default async function resolveConfig(commander) {
   await validateFilesToProcess(filesToProcess);
   return {
     filesToProcess,
+    fixImportsConfig: config.fixImportsConfig,
     jscodeshiftScripts: config.jscodeshiftScripts,
     mochaEnvFilePattern: config.mochaEnvFilePattern,
     decaffeinatePath: await resolveDecaffeinatePath(config),
@@ -90,7 +91,7 @@ async function resolveDecaffeinatePath(config) {
 async function resolveJscodeshiftPath(config) {
   // jscodeshift is an optional step, so don't prompt to install it if we won't
   // be using it.
-  if (!config.jscodeshiftScripts) {
+  if (!config.jscodeshiftScripts && !config.fixImportsConfig) {
     return null;
   }
   if (config.jscodeshiftPath) {

--- a/test/examples/fix-imports-absolute-imports/absolute-import-source/ImportSource.coffee
+++ b/test/examples/fix-imports-absolute-imports/absolute-import-source/ImportSource.coffee
@@ -1,0 +1,2 @@
+ImportTarget = require 'absolute-import-target/ImportTarget'
+console.log ImportTarget.num

--- a/test/examples/fix-imports-absolute-imports/absolute-import-source/ImportSource.js.expected
+++ b/test/examples/fix-imports-absolute-imports/absolute-import-source/ImportSource.js.expected
@@ -1,0 +1,4 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+import * as ImportTarget from 'absolute-import-target/ImportTarget';
+console.log(ImportTarget.num);

--- a/test/examples/fix-imports-absolute-imports/absolute-import-target/ImportTarget.coffee
+++ b/test/examples/fix-imports-absolute-imports/absolute-import-target/ImportTarget.coffee
@@ -1,0 +1,1 @@
+module.exports.num = 7

--- a/test/examples/fix-imports-absolute-imports/absolute-import-target/ImportTarget.js.expected
+++ b/test/examples/fix-imports-absolute-imports/absolute-import-target/ImportTarget.js.expected
@@ -1,0 +1,3 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+export let num = 7;

--- a/test/examples/fix-imports-absolute-imports/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-absolute-imports/bulk-decaffeinate.json
@@ -1,0 +1,6 @@
+{
+  "fixImportsConfig": {
+    "searchPath": ".",
+    "absoluteImportPaths": ["."]
+  }
+}

--- a/test/examples/fix-imports-default-import-to-import-star/NamedExport.coffee
+++ b/test/examples/fix-imports-default-import-to-import-star/NamedExport.coffee
@@ -1,0 +1,1 @@
+module.exports.value = 3

--- a/test/examples/fix-imports-default-import-to-import-star/NamedExport.js.expected
+++ b/test/examples/fix-imports-default-import-to-import-star/NamedExport.js.expected
@@ -1,0 +1,3 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+export let value = 3;

--- a/test/examples/fix-imports-default-import-to-import-star/NormalImport.coffee
+++ b/test/examples/fix-imports-default-import-to-import-star/NormalImport.coffee
@@ -1,0 +1,2 @@
+NamedExport = require './NamedExport'
+console.log NamedExport.value

--- a/test/examples/fix-imports-default-import-to-import-star/NormalImport.js.expected
+++ b/test/examples/fix-imports-default-import-to-import-star/NormalImport.js.expected
@@ -1,0 +1,4 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+import * as NamedExport from './NamedExport';
+console.log(NamedExport.value);

--- a/test/examples/fix-imports-default-import-to-import-star/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-default-import-to-import-star/bulk-decaffeinate.json
@@ -1,0 +1,5 @@
+{
+  "fixImportsConfig": {
+    "searchPath": "."
+  }
+}

--- a/test/examples/fix-imports-destructure-from-import-star/ConvertedCoffeeFile.coffee
+++ b/test/examples/fix-imports-destructure-from-import-star/ConvertedCoffeeFile.coffee
@@ -1,0 +1,2 @@
+module.exports.firstExport = 1
+module.exports.secondExport = 2

--- a/test/examples/fix-imports-destructure-from-import-star/ConvertedCoffeeFile.js.expected
+++ b/test/examples/fix-imports-destructure-from-import-star/ConvertedCoffeeFile.js.expected
@@ -1,0 +1,4 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+export let firstExport = 1;
+export let secondExport = 2;

--- a/test/examples/fix-imports-destructure-from-import-star/ExistingMultiImportFile.js
+++ b/test/examples/fix-imports-destructure-from-import-star/ExistingMultiImportFile.js
@@ -1,0 +1,4 @@
+import ConvertedCoffeeFile, {secondExport as s} from './ConvertedCoffeeFile';
+
+console.log(ConvertedCoffeeFile.firstExport);
+console.log(s);

--- a/test/examples/fix-imports-destructure-from-import-star/ExistingMultiImportFile.js.expected
+++ b/test/examples/fix-imports-destructure-from-import-star/ExistingMultiImportFile.js.expected
@@ -1,0 +1,8 @@
+import * as ConvertedCoffeeFile from './ConvertedCoffeeFile';
+
+const {
+  secondExport: s
+} = ConvertedCoffeeFile;
+
+console.log(ConvertedCoffeeFile.firstExport);
+console.log(s);

--- a/test/examples/fix-imports-destructure-from-import-star/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-destructure-from-import-star/bulk-decaffeinate.json
@@ -1,0 +1,5 @@
+{
+  "fixImportsConfig": {
+    "searchPath": "."
+  }
+}

--- a/test/examples/fix-imports-import-from-existing-js/ConvertedCoffeeFile.coffee
+++ b/test/examples/fix-imports-import-from-existing-js/ConvertedCoffeeFile.coffee
@@ -1,0 +1,4 @@
+module.exports = {
+  firstValue: 1
+}
+module.exports.secondValue = 2

--- a/test/examples/fix-imports-import-from-existing-js/ConvertedCoffeeFile.js.expected
+++ b/test/examples/fix-imports-import-from-existing-js/ConvertedCoffeeFile.js.expected
@@ -1,0 +1,6 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+export default {
+  firstValue: 1
+};
+export let secondValue = 2;

--- a/test/examples/fix-imports-import-from-existing-js/ExistingJSFile.js
+++ b/test/examples/fix-imports-import-from-existing-js/ExistingJSFile.js
@@ -1,0 +1,4 @@
+import ConvertedCoffeeFile from './ConvertedCoffeeFile';
+
+console.log(ConvertedCoffeeFile.firstValue);
+console.log(ConvertedCoffeeFile.secondValue);

--- a/test/examples/fix-imports-import-from-existing-js/ExistingJSFile.js.expected
+++ b/test/examples/fix-imports-import-from-existing-js/ExistingJSFile.js.expected
@@ -1,0 +1,4 @@
+import ConvertedCoffeeFile, * as ConvertedCoffeeFileExports from './ConvertedCoffeeFile';
+
+console.log(ConvertedCoffeeFile.firstValue);
+console.log(ConvertedCoffeeFileExports.secondValue);

--- a/test/examples/fix-imports-import-from-existing-js/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-import-from-existing-js/bulk-decaffeinate.json
@@ -1,0 +1,5 @@
+{
+  "fixImportsConfig": {
+    "searchPath": "."
+  }
+}

--- a/test/examples/fix-imports-named-import-to-destructure/NameClash.coffee
+++ b/test/examples/fix-imports-named-import-to-destructure/NameClash.coffee
@@ -1,0 +1,3 @@
+module.exports = {
+  twenty: 20
+}

--- a/test/examples/fix-imports-named-import-to-destructure/NameClash.js.expected
+++ b/test/examples/fix-imports-named-import-to-destructure/NameClash.js.expected
@@ -1,0 +1,5 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+export default {
+  twenty: 20
+};

--- a/test/examples/fix-imports-named-import-to-destructure/NamedExport.coffee
+++ b/test/examples/fix-imports-named-import-to-destructure/NamedExport.coffee
@@ -1,0 +1,1 @@
+exports.twentySix = 26;

--- a/test/examples/fix-imports-named-import-to-destructure/NamedExport.js.expected
+++ b/test/examples/fix-imports-named-import-to-destructure/NamedExport.js.expected
@@ -1,0 +1,3 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+export let twentySix = 26;

--- a/test/examples/fix-imports-named-import-to-destructure/NamedImport.coffee
+++ b/test/examples/fix-imports-named-import-to-destructure/NamedImport.coffee
@@ -1,0 +1,11 @@
+{twelve, seventeen: tenAndSeven} = require './TwoValueDefaultExport'
+{twenty} = require './NameClash'
+{twentySix} = require './NamedExport';
+{thirtyOne} = require './dashed-name'
+console.log twelve;
+console.log tenAndSeven;
+NameClash = 25
+console.log twenty;
+console.log twentySix;
+console.log NameClash;
+console.log thirtyOne;

--- a/test/examples/fix-imports-named-import-to-destructure/NamedImport.js.expected
+++ b/test/examples/fix-imports-named-import-to-destructure/NamedImport.js.expected
@@ -1,0 +1,29 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+import TwoValueDefaultExport from './TwoValueDefaultExport';
+
+const {
+  twelve,
+  seventeen: tenAndSeven
+} = TwoValueDefaultExport;
+
+import NameClash1 from './NameClash';
+
+const {
+  twenty
+} = NameClash1;
+
+import { twentySix } from './NamedExport';
+import DashedName from './dashed-name';
+
+const {
+  thirtyOne
+} = DashedName;
+
+console.log(twelve);
+console.log(tenAndSeven);
+let NameClash = 25;
+console.log(twenty);
+console.log(twentySix);
+console.log(NameClash);
+console.log(thirtyOne);

--- a/test/examples/fix-imports-named-import-to-destructure/TwoValueDefaultExport.coffee
+++ b/test/examples/fix-imports-named-import-to-destructure/TwoValueDefaultExport.coffee
@@ -1,0 +1,4 @@
+module.exports = {
+  twelve: 12
+  seventeen: 17
+}

--- a/test/examples/fix-imports-named-import-to-destructure/TwoValueDefaultExport.js.expected
+++ b/test/examples/fix-imports-named-import-to-destructure/TwoValueDefaultExport.js.expected
@@ -1,0 +1,6 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+export default {
+  twelve: 12,
+  seventeen: 17
+};

--- a/test/examples/fix-imports-named-import-to-destructure/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-named-import-to-destructure/bulk-decaffeinate.json
@@ -1,0 +1,5 @@
+{
+  "fixImportsConfig": {
+    "searchPath": "."
+  }
+}

--- a/test/examples/fix-imports-named-import-to-destructure/dashed-name.coffee
+++ b/test/examples/fix-imports-named-import-to-destructure/dashed-name.coffee
@@ -1,0 +1,3 @@
+module.exports = {
+  thirtyOne: 31
+}

--- a/test/examples/fix-imports-named-import-to-destructure/dashed-name.js.expected
+++ b/test/examples/fix-imports-named-import-to-destructure/dashed-name.js.expected
@@ -1,0 +1,5 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+export default {
+  thirtyOne: 31
+};

--- a/test/examples/fix-imports-star-import-from-existing-js/ObjectExport.coffee
+++ b/test/examples/fix-imports-star-import-from-existing-js/ObjectExport.coffee
@@ -1,0 +1,4 @@
+module.exports = {
+  firstValue: 1,
+  secondValue: 2
+}

--- a/test/examples/fix-imports-star-import-from-existing-js/ObjectExport.js.expected
+++ b/test/examples/fix-imports-star-import-from-existing-js/ObjectExport.js.expected
@@ -1,0 +1,6 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+export default {
+  firstValue: 1,
+  secondValue: 2
+};

--- a/test/examples/fix-imports-star-import-from-existing-js/StarImportJSFile.js
+++ b/test/examples/fix-imports-star-import-from-existing-js/StarImportJSFile.js
@@ -1,0 +1,4 @@
+import * as ObjectExport from './ObjectExport';
+
+console.log(ObjectExport.firstValue);
+console.log(ObjectExport.secondValue);

--- a/test/examples/fix-imports-star-import-from-existing-js/StarImportJSFile.js.expected
+++ b/test/examples/fix-imports-star-import-from-existing-js/StarImportJSFile.js.expected
@@ -1,0 +1,4 @@
+import ObjectExport from './ObjectExport';
+
+console.log(ObjectExport.firstValue);
+console.log(ObjectExport.secondValue);

--- a/test/examples/fix-imports-star-import-from-existing-js/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-star-import-from-existing-js/bulk-decaffeinate.json
@@ -1,0 +1,5 @@
+{
+  "fixImportsConfig": {
+    "searchPath": "."
+  }
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
 --compilers js:babel-register
---timeout 20000
+--timeout 60000


### PR DESCRIPTION
This ended up being a pretty complicated change, so I documented the new script
thoroughly and wrote a bunch of tests. Since decaffeinate only works on
individual files, it doesn't know how to translate imports from commonjs to the
new JavaScript import/export style, and it can produce either default or named
exports without attempting to fix up import usages. So this commit introduces a
jscodeshift script that runs across the whole codebase and reworks any imports
in decaffeinated files and any imports that reference decaffeinated files.

There end up being a bunch of cases, since the file being imported might have
mixed named/default exports. But I think this should handle just about any case
that decaffeinate can produce.

See https://github.com/decaffeinate/decaffeinate/issues/402 for more information.