### PR TITLE
fix: keep imports even when no fields are used

### DIFF
--- a/jscodeshift-scripts/fix-imports.js
+++ b/jscodeshift-scripts/fix-imports.js
@@ -91,8 +91,15 @@ export default function (fileInfo, api, options) {
     // (e.g. MyModule.myExport), then handle those with a star import. If we
     // also have direct usages of named exports (e.g. myOtherExport), we'll need
     // to destructure them from the * import later, but we try to avoid that
-    // when possible.
-    let needsStarImport = importManifest.namedImportObjectAccesses.length > 0;
+    // when possible. Also, if a default or star import originally existed, that
+    // name needs to stay bound somehow, so we make sure to include it as a star
+    // import if the other module didn't have a default export.
+    let needsStarImport =
+      importManifest.namedImportObjectAccesses.length > 0 ||
+      (!needsDefaultImport &&
+        (specifierIndex.defaultImport !== null ||
+        specifierIndex.starImport !== null)
+      );
 
     let {defaultImportName, starImportName} = resolveImportObjectNames(
       specifierIndex, needsDefaultImport, needsStarImport,

--- a/test/examples/fix-imports-no-name-usages/DirectModuleUsage.coffee
+++ b/test/examples/fix-imports-no-name-usages/DirectModuleUsage.coffee
@@ -1,0 +1,2 @@
+NamedExports = require './NamedExports'
+console.log(NamedExports)

--- a/test/examples/fix-imports-no-name-usages/DirectModuleUsage.js.expected
+++ b/test/examples/fix-imports-no-name-usages/DirectModuleUsage.js.expected
@@ -1,0 +1,4 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+import * as NamedExports from './NamedExports';
+console.log(NamedExports);

--- a/test/examples/fix-imports-no-name-usages/NamedExports.js
+++ b/test/examples/fix-imports-no-name-usages/NamedExports.js
@@ -1,0 +1,2 @@
+export let x = 3;
+export let y = 4;

--- a/test/examples/fix-imports-no-name-usages/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-no-name-usages/bulk-decaffeinate.json
@@ -1,0 +1,5 @@
+{
+  "fixImportsConfig": {
+    "searchPath": "."
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -279,4 +279,8 @@ describe('fix-imports', () => {
   it('properly reads exports when "export function" is used', async function() {
     await runFixImportsTest('fix-imports-export-function');
   });
+
+  it('uses an import * import when necessary even when there are no name usages', async function() {
+    await runFixImportsTest('fix-imports-no-name-usages');
+  });
 });


### PR DESCRIPTION
In some cases, a name could be imported and only used by itself (e.g. passed
into a mocking function). If the other side had a default export, then this
would be fine, but if the other side had no default export, we would just leave
off any type of import name. Now, we instead switch the import to an `import *`
in that case.