### PR TITLE
fix: add all files after running fix-imports, not just decaffeinated files

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -111,10 +111,8 @@ Re-run with the "check" command for more details.`);
     }
   }
 
-  await runCommand(
-    'Running git add on all files again...',
-    p => `git add ${p}.js`,
-    {runInSeries: true});
+  console.log(`Running git add for all files with changes...`);
+  await exec(`git add -u`);
 
   let postProcessCommitMsg =
     `decaffeinate: Run post-processing cleanups on ${pluralize(baseFiles.length, 'file')}`;

--- a/test/test.js
+++ b/test/test.js
@@ -289,6 +289,8 @@ describe('fix-imports', () => {
         let actualFile = expectedFile.substr(0, expectedFile.length - '.expected'.length);
         await assertFilesEqual(actualFile, expectedFile);
       }
+      let changedFiles = (await exec('git status --short --untracked-files=no'))[0];
+      assert.equal(changedFiles, '', 'Expected all file changes to be committed.');
     });
   }
 


### PR DESCRIPTION
jscodeshift discovers and converts and files importing a file that was run
through decaffeinate, so we don't have a nice list of files to `git add`. But we
already made sure at the start that the git worktree has no changes, so it
should be safe to just add all files.