### PR TITLE
fix: avoid crash in fix-imports by switching to commonjs

### DIFF
--- a/jscodeshift-scripts/fix-imports.js
+++ b/jscodeshift-scripts/fix-imports.js
@@ -18,10 +18,10 @@
  * See https://github.com/decaffeinate/decaffeinate/issues/402 for some more
  * details on why decaffeinate can't solve this itself.
  */
-import { existsSync, readFileSync } from 'fs';
-import path from 'path';
+const { existsSync, readFileSync } = require('fs');
+const path = require('path');
 
-export default function (fileInfo, api, options) {
+module.exports = function (fileInfo, api, options) {
   let decodedOptions = JSON.parse(new Buffer(options['encoded-options'], 'base64'));
   let {convertedFiles, absoluteImportPaths} = decodedOptions;
   let j = api.jscodeshift;
@@ -520,7 +520,7 @@ export default function (fileInfo, api, options) {
   }
 
   return convertFile();
-}
+};
 
 /**
  * Little helper since we don't have Array.prototype.includes.


### PR DESCRIPTION
It looks like the babel config was set up right when I was testing locally, but
not when running from a real package, so there would be an "unexpected token"
error. The easy (though ironic) fix is to just use commonjs style for the script
itself.