### PR TITLE
feat: change the recommended config file format from JSON to JS

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,11 +6,13 @@
     "node": true
   },
   "rules": {
+    "comma-dangle": [2, "always-multiline"],
     "semi": 2,
     "no-var": 2,
     "strict": 0,
     "no-console": 0,
     "quotes": [2, "single", {"avoidEscape": true, "allowTemplateLiterals": true}],
+    "quote-props": [2, "as-needed"],
     "no-use-before-define": [2, "nofunc"],
     "eqeqeq": 2,
     "babel/object-shorthand": 1,

--- a/README.md
+++ b/README.md
@@ -110,14 +110,31 @@ hopefully be fairly readable.
 ## Configuration
 
 You can specify custom configuration in a config file, usually called
-`bulk-decaffeinate.json`, in the current working directory. Any file starting
-with `bulk-decaffeinate` and ending with `.json` will be counted, and multiple
-config files may exist at once. If there are multiple config files, they are
-merged, with alphabetically-later config file names taking precedence over
-alphabetically-earlier files. Many config options can also be specified directly
-as CLI arguments, with CLI arguments taking precedence over any config file
-setting.
+`bulk-decaffeinate.config.js`, in the current working directory. It should
+export a JS object with your config. Any file starting with `bulk-decaffeinate`
+and ending with `.config.js` will be counted, and multiple config files may
+exist at once. If there are multiple config files, they are merged, with
+alphabetically-later config file names taking precedence over
+alphabetically-earlier files. Many config options can also be specified
+directly as CLI arguments, with CLI arguments taking precedence over any config
+file setting.
 
+Here's an example config file:
+
+```js
+module.exports = {
+  jscodeshiftScripts: [
+    './scripts/dev/codemods/arrow-function.js',
+    './scripts/dev/codemods/rd-to-create-element.js',
+    './scripts/dev/codemods/create-element-to-jsx.js',
+  ],
+  mochaEnvFilePattern: '^.*-test.js$',
+  fixImportsConfig: {
+    searchPath: './coffee',
+    absoluteImportPaths: ['./coffee'],
+  },
+};
+```
 
 ### Specifying files to process
 

--- a/jscodeshift-scripts/fix-imports.js
+++ b/jscodeshift-scripts/fix-imports.js
@@ -233,7 +233,7 @@ module.exports = function (fileInfo, api, options) {
     return {
       defaultImportAccesses,
       starImportAccesses,
-      directAccesses
+      directAccesses,
     };
   }
 
@@ -247,8 +247,8 @@ module.exports = function (fileInfo, api, options) {
     root
       .find(j.MemberExpression, {
         object: {
-          name: objectName
-        }
+          name: objectName,
+        },
       })
       .forEach(path => {
         if (path.node.property.type === 'Identifier') {
@@ -514,7 +514,7 @@ module.exports = function (fileInfo, api, options) {
         j.variableDeclarator(
           j.objectPattern(properties),
           j.identifier(objName)
-        )
+        ),
       ]
     );
   }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "babel-polyfill": "^6.13.0",
     "commander": "^2.9.0",
     "mz": "^2.4.0",
-    "opn": "^4.0.2"
+    "opn": "^4.0.2",
+    "require-uncached": "^1.0.2"
   }
 }

--- a/test/examples/fix-imports-absolute-imports/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-absolute-imports/bulk-decaffeinate.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  fixImportsConfig: {
+    searchPath: '.',
+    absoluteImportPaths: ['.'],
+  },
+};

--- a/test/examples/fix-imports-absolute-imports/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-absolute-imports/bulk-decaffeinate.json
@@ -1,6 +1,0 @@
-{
-  "fixImportsConfig": {
-    "searchPath": ".",
-    "absoluteImportPaths": ["."]
-  }
-}

--- a/test/examples/fix-imports-default-import-to-import-star/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-default-import-to-import-star/bulk-decaffeinate.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  fixImportsConfig: {
+    searchPath: '.',
+  },
+};

--- a/test/examples/fix-imports-default-import-to-import-star/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-default-import-to-import-star/bulk-decaffeinate.json
@@ -1,5 +1,0 @@
-{
-  "fixImportsConfig": {
-    "searchPath": "."
-  }
-}

--- a/test/examples/fix-imports-destructure-from-import-star/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-destructure-from-import-star/bulk-decaffeinate.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  fixImportsConfig: {
+    searchPath: '.',
+  },
+};

--- a/test/examples/fix-imports-destructure-from-import-star/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-destructure-from-import-star/bulk-decaffeinate.json
@@ -1,5 +1,0 @@
-{
-  "fixImportsConfig": {
-    "searchPath": "."
-  }
-}

--- a/test/examples/fix-imports-export-function/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-export-function/bulk-decaffeinate.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  fixImportsConfig: {
+    searchPath: '.',
+  },
+};

--- a/test/examples/fix-imports-export-function/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-export-function/bulk-decaffeinate.json
@@ -1,5 +1,0 @@
-{
-  "fixImportsConfig": {
-    "searchPath": "."
-  }
-}

--- a/test/examples/fix-imports-import-from-existing-js/ConvertedCoffeeFile.js.expected
+++ b/test/examples/fix-imports-import-from-existing-js/ConvertedCoffeeFile.js.expected
@@ -1,6 +1,6 @@
 // TODO: This file was created by bulk-decaffeinate.
 // Sanity-check the conversion and remove this comment.
 export default {
-  firstValue: 1
+  firstValue: 1,
 };
 export let secondValue = 2;

--- a/test/examples/fix-imports-import-from-existing-js/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-import-from-existing-js/bulk-decaffeinate.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  fixImportsConfig: {
+    searchPath: '.',
+  },
+};

--- a/test/examples/fix-imports-import-from-existing-js/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-import-from-existing-js/bulk-decaffeinate.json
@@ -1,5 +1,0 @@
-{
-  "fixImportsConfig": {
-    "searchPath": "."
-  }
-}

--- a/test/examples/fix-imports-named-import-to-destructure/NameClash.js.expected
+++ b/test/examples/fix-imports-named-import-to-destructure/NameClash.js.expected
@@ -1,5 +1,5 @@
 // TODO: This file was created by bulk-decaffeinate.
 // Sanity-check the conversion and remove this comment.
 export default {
-  twenty: 20
+  twenty: 20,
 };

--- a/test/examples/fix-imports-named-import-to-destructure/NamedImport.js.expected
+++ b/test/examples/fix-imports-named-import-to-destructure/NamedImport.js.expected
@@ -4,20 +4,20 @@ import TwoValueDefaultExport from './TwoValueDefaultExport';
 
 const {
   twelve,
-  seventeen: tenAndSeven
+  seventeen: tenAndSeven,
 } = TwoValueDefaultExport;
 
 import NameClash1 from './NameClash';
 
 const {
-  twenty
+  twenty,
 } = NameClash1;
 
 import { twentySix } from './NamedExport';
 import DashedName from './dashed-name';
 
 const {
-  thirtyOne
+  thirtyOne,
 } = DashedName;
 
 console.log(twelve);

--- a/test/examples/fix-imports-named-import-to-destructure/TwoValueDefaultExport.js.expected
+++ b/test/examples/fix-imports-named-import-to-destructure/TwoValueDefaultExport.js.expected
@@ -2,5 +2,5 @@
 // Sanity-check the conversion and remove this comment.
 export default {
   twelve: 12,
-  seventeen: 17
+  seventeen: 17,
 };

--- a/test/examples/fix-imports-named-import-to-destructure/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-named-import-to-destructure/bulk-decaffeinate.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  fixImportsConfig: {
+    searchPath: '.',
+  },
+};

--- a/test/examples/fix-imports-named-import-to-destructure/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-named-import-to-destructure/bulk-decaffeinate.json
@@ -1,5 +1,0 @@
-{
-  "fixImportsConfig": {
-    "searchPath": "."
-  }
-}

--- a/test/examples/fix-imports-named-import-to-destructure/dashed-name.js.expected
+++ b/test/examples/fix-imports-named-import-to-destructure/dashed-name.js.expected
@@ -1,5 +1,5 @@
 // TODO: This file was created by bulk-decaffeinate.
 // Sanity-check the conversion and remove this comment.
 export default {
-  thirtyOne: 31
+  thirtyOne: 31,
 };

--- a/test/examples/fix-imports-no-name-usages/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-no-name-usages/bulk-decaffeinate.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  fixImportsConfig: {
+    searchPath: '.',
+  },
+};

--- a/test/examples/fix-imports-no-name-usages/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-no-name-usages/bulk-decaffeinate.json
@@ -1,5 +1,0 @@
-{
-  "fixImportsConfig": {
-    "searchPath": "."
-  }
-}

--- a/test/examples/fix-imports-star-import-from-existing-js/ObjectExport.js.expected
+++ b/test/examples/fix-imports-star-import-from-existing-js/ObjectExport.js.expected
@@ -2,5 +2,5 @@
 // Sanity-check the conversion and remove this comment.
 export default {
   firstValue: 1,
-  secondValue: 2
+  secondValue: 2,
 };

--- a/test/examples/fix-imports-star-import-from-existing-js/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-star-import-from-existing-js/bulk-decaffeinate.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  fixImportsConfig: {
+    searchPath: '.',
+  },
+};

--- a/test/examples/fix-imports-star-import-from-existing-js/bulk-decaffeinate.json
+++ b/test/examples/fix-imports-star-import-from-existing-js/bulk-decaffeinate.json
@@ -1,5 +1,0 @@
-{
-  "fixImportsConfig": {
-    "searchPath": "."
-  }
-}

--- a/test/examples/jscodeshift-test/bulk-decaffeinate.config.js
+++ b/test/examples/jscodeshift-test/bulk-decaffeinate.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  jscodeshiftScripts: [
+    './change-name.js',
+  ],
+};

--- a/test/examples/jscodeshift-test/bulk-decaffeinate.json
+++ b/test/examples/jscodeshift-test/bulk-decaffeinate.json
@@ -1,5 +1,0 @@
-{
-  "jscodeshiftScripts": [
-    "./change-name.js"
-  ]
-}

--- a/test/examples/mocha-env-test/bulk-decaffeinate.config.js
+++ b/test/examples/mocha-env-test/bulk-decaffeinate.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  mochaEnvFilePattern: '^.*-test.js$',
+};

--- a/test/examples/mocha-env-test/bulk-decaffeinate.json
+++ b/test/examples/mocha-env-test/bulk-decaffeinate.json
@@ -1,3 +1,0 @@
-{
-  "mochaEnvFilePattern": "^.*-test.js$"
-}

--- a/test/examples/simple-config-file/bulk-decaffeinate.config.js
+++ b/test/examples/simple-config-file/bulk-decaffeinate.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  filesToProcess: [
+    'A.coffee',
+  ],
+};

--- a/test/examples/simple-config-file/bulk-decaffeinate.json
+++ b/test/examples/simple-config-file/bulk-decaffeinate.json
@@ -1,5 +1,0 @@
-{
-  "filesToProcess": [
-    "A.coffee"
-  ]
-}

--- a/test/test.js
+++ b/test/test.js
@@ -137,7 +137,8 @@ describe('file-list', () => {
 describe('config files', () => {
   it('reads the list of files from a config file', async function() {
     await runWithTemplateDir('simple-config-file', async function() {
-      let {stdout} = await runCli('check');
+      let {stdout, stderr} = await runCli('check');
+      assert.equal(stderr, '');
       assertIncludes(stdout, 'Doing a dry run of decaffeinate on 1 file...');
       assertIncludes(stdout, 'All checks succeeded');
     });


### PR DESCRIPTION
Comments are useful for config files, and tailing commas and various JS features
are nice-to-have in config files, so I'm changing the format to just use JS. The
main downside is you need a `module.exports` at the start, but that seems like
not a huge deal. I used eslint's approach here: resolve the file to an abolute
path and use the `require-uncached` module.

JSON is still supported in case anyone wants it, but it's no longer documented
or tested, and may be removed in a later major version bump.