### PR TITLE
fix: properly detect relative vs non-relative imports in fix-imports

### DIFF
--- a/jscodeshift-scripts/fix-imports.js
+++ b/jscodeshift-scripts/fix-imports.js
@@ -129,15 +129,18 @@ module.exports = function (fileInfo, api, options) {
     if (!importPath.endsWith('.js')) {
       importPath += '.js';
     }
-    let currentDir = path.dirname(importingFilePath);
-    let relativePath = path.resolve(currentDir, importPath);
-    if (existsSync(relativePath)) {
-      return relativePath;
-    }
-    for (let absoluteImportPath of absoluteImportPaths) {
-      let absolutePath = path.resolve(absoluteImportPath, importPath);
-      if (existsSync(absolutePath)) {
-        return absolutePath;
+    if (importPath.startsWith('.')) {
+      let currentDir = path.dirname(importingFilePath);
+      let relativePath = path.resolve(currentDir, importPath);
+      if (existsSync(relativePath)) {
+        return relativePath;
+      }
+    } else {
+      for (let absoluteImportPath of absoluteImportPaths) {
+        let absolutePath = path.resolve(absoluteImportPath, importPath);
+        if (existsSync(absolutePath)) {
+          return absolutePath;
+        }
       }
     }
     return null;

--- a/test/examples/fix-imports-non-relative-path/NonRelativePath.coffee
+++ b/test/examples/fix-imports-non-relative-path/NonRelativePath.coffee
@@ -1,0 +1,6 @@
+# This actually references something in node_modules.
+NonRelativePath = require 'NonRelativePath'
+
+console.log NonRelativePath.foo
+
+module.exports.foo = 3

--- a/test/examples/fix-imports-non-relative-path/NonRelativePath.js.expected
+++ b/test/examples/fix-imports-non-relative-path/NonRelativePath.js.expected
@@ -1,0 +1,8 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Sanity-check the conversion and remove this comment.
+// This actually references something in node_modules.
+import NonRelativePath from 'NonRelativePath';
+
+console.log(NonRelativePath.foo);
+
+export let foo = 3;

--- a/test/examples/fix-imports-non-relative-path/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-non-relative-path/bulk-decaffeinate.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  fixImportsConfig: {
+    searchPath: '.',
+  },
+};

--- a/test/test.js
+++ b/test/test.js
@@ -326,4 +326,8 @@ describe('fix-imports', () => {
   it('uses an import * import when necessary even when there are no name usages', async function() {
     await runFixImportsTest('fix-imports-no-name-usages');
   });
+
+  it('only does relative path resolution when an import is relative style', async function() {
+    await runFixImportsTest('fix-imports-non-relative-path');
+  });
 });


### PR DESCRIPTION
This fixes an issue where an import like 'foo' would look for 'foo.js' in the
current directory and have that take precedence over global or node_modules
matches, which is wrong. Now, we see if the first letter is '.' to know if the
import is relative or absolute.