### PR TITLE
fix: run the fix-imports script through babel as part of the build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist
 decaffeinate-errors.log
 decaffeinate-results.json
 decaffeinate-successful-files.txt
+jscodeshift-scripts-dist
 test/tmp-projects

--- a/jscodeshift-scripts/fix-imports.js
+++ b/jscodeshift-scripts/fix-imports.js
@@ -18,10 +18,10 @@
  * See https://github.com/decaffeinate/decaffeinate/issues/402 for some more
  * details on why decaffeinate can't solve this itself.
  */
-const { existsSync, readFileSync } = require('fs');
-const path = require('path');
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
 
-module.exports = function (fileInfo, api, options) {
+export default function (fileInfo, api, options) {
   let decodedOptions = JSON.parse(new Buffer(options['encoded-options'], 'base64'));
   let {convertedFiles, absoluteImportPaths} = decodedOptions;
   let j = api.jscodeshift;
@@ -523,7 +523,7 @@ module.exports = function (fileInfo, api, options) {
   }
 
   return convertFile();
-};
+}
 
 /**
  * Little helper since we don't have Array.prototype.includes.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "prebuild": "npm run lint",
-    "build": "rollup -c",
+    "build": "rollup -c && babel jscodeshift-scripts --out-dir jscodeshift-scripts-dist",
     "lint": "eslint src test jscodeshift-scripts",
     "pretest": "npm run build",
     "test": "mocha",
@@ -29,13 +29,14 @@
   "files": [
     "bin",
     "dist",
-    "jscodeshift-scripts"
+    "jscodeshift-scripts-dist"
   ],
   "bugs": {
     "url": "https://github.com/alangpierce/bulk-decaffeinate/issues"
   },
   "homepage": "https://github.com/alangpierce/bulk-decaffeinate#readme",
   "devDependencies": {
+    "babel-cli": "^6.16.0",
     "babel-eslint": "^7.0.0",
     "babel-plugin-external-helpers": "^6.8.0",
     "babel-plugin-syntax-async-functions": "^6.13.0",

--- a/src/convert.js
+++ b/src/convert.js
@@ -91,7 +91,7 @@ Re-run with the "check" command for more details.`);
     if (!absoluteImportPaths) {
       absoluteImportPaths = [];
     }
-    let scriptPath = path.join(__dirname, '../jscodeshift-scripts/fix-imports.js');
+    let scriptPath = path.join(__dirname, '../jscodeshift-scripts-dist/fix-imports.js');
     console.log('Fixing any imports across the whole codebase...');
     let options = {
       convertedFiles: jsFiles.map(p => path.resolve(p)),


### PR DESCRIPTION
The fix-imports script worked when run from source (using `npm link`), but not
when bulk-decaffeinate was installed as a package. The issue is that
jscodeshift wasn't properly running babel (I think because the file was within
node_modules), so the simple fix is to just run babel myself and ship the
compiled version.