### PR TITLE
feat: allow specifying files from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ The following config keys can be specified:
 The `filesToProcess` setting has highest precedence, then `pathFile`, then
 `searchDirectory`.
 
+Each of these has a command line arg version; see the result of `--help` for
+more information.
+
 ### Other configuration
 
 * `jscodeshiftScripts`: an optional array of paths to

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,30 +16,33 @@ export default function () {
 
   Commands:
     check: Try decaffeinate on the specified files and generate a report of
-      which files can be converted. By default, all .coffee files in the current
-      directory are used.
+                            which files can be converted. By default, all .coffee files in the current
+                            directory are used.
     convert: Run decaffeinate on the specified files and generate git commits
-      for the transition.
+                            for the transition.
     view-errors: Open failures from the most recent run in an online repl.
     clean: Delete all files ending with .original.coffee in the current
-      working directory or any of its subdirectories.`)
+                            working directory or any of its subdirectories.`)
     .action(commandArg => command = commandArg)
+    .option('-f, --file [path]',
+      `An absolute or relative path to decaffeinate. This arg may be specified 
+                            multiple times.`, (arg, args) => {args.push(arg); return args;}, [])
     .option('-p, --path-file [path]',
       `A file containing the paths of .coffee files to decaffeinate, one
-        path per line. Paths can be either absolute or relative to the
-        current working directory.`)
+                            path per line. Paths can be either absolute or relative to the
+                            current working directory.`)
     .option('-d, --dir [path]',
       `A directory containing files to decaffeinate. All .coffee files in any
-        subdirectory of this directory are considered for decaffeinate.`)
+                            subdirectory of this directory are considered for decaffeinate.`)
     .option('--decaffeinate-path [path]',
       `The path to the decaffeinate binary. If none is specified, it will be
-        automatically discovered from node_modules and then from the PATH.`)
+                            automatically discovered from node_modules and then from the PATH.`)
     .option('--jscodeshift-path [path]',
       `The path to the jscodeshift binary. If none is specified, it will be
-        automatically discovered from node_modules and then from the PATH.`)
+                            automatically discovered from node_modules and then from the PATH.`)
     .option('--eslint-path [path]',
       `The path to the eslint binary. If none is specified, it will be
-        automatically discovered from node_modules and then from the PATH.`)
+                            automatically discovered from node_modules and then from the PATH.`)
     .parse(process.argv);
 
   runCommand(command);

--- a/src/config/resolveConfig.js
+++ b/src/config/resolveConfig.js
@@ -68,8 +68,11 @@ async function applyPossibleConfig(filename, config) {
  * Fill in a configuration from the CLI arguments.
  */
 function getCLIParamsConfig(commander) {
-  let {pathFile, dir, decaffeinatePath, jscodeshiftPath, eslintPath} = commander;
+  let {file, pathFile, dir, decaffeinatePath, jscodeshiftPath, eslintPath} = commander;
   let config = {};
+  if (file && file.length > 0) {
+    config.filesToProcess = file;
+  }
   if (dir) {
     config.searchDirectory = dir;
   }

--- a/test/test.js
+++ b/test/test.js
@@ -134,6 +134,22 @@ describe('file-list', () => {
   });
 });
 
+describe('specifying individual files', () => {
+  it('allows specifying one file', async function() {
+    let {stdout} = await runCli('check --file test/examples/simple-success/A.coffee');
+    assertIncludes(stdout, 'Doing a dry run of decaffeinate on 1 file...');
+    assertIncludes(stdout, 'All checks succeeded');
+  });
+
+  it('allows specifying two files', async function() {
+    let {stdout} = await runCli(
+      `check --file test/examples/simple-success/A.coffee \
+        --file test/examples/simple-success/B.coffee`);
+    assertIncludes(stdout, 'Doing a dry run of decaffeinate on 2 files...');
+    assertIncludes(stdout, 'All checks succeeded');
+  });
+});
+
 describe('config files', () => {
   it('reads the list of files from a config file', async function() {
     await runWithTemplateDir('simple-config-file', async function() {


### PR DESCRIPTION
This makes it easier to convert just one or two files, and makes some tests
easier to write.