### PR TITLE
fix: show nicer-looking commit messages

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -38,8 +38,9 @@ Re-run with the "check" command for more details.`);
     {runInSeries: true});
 
   let gitAuthor = await getGitAuthor();
+  let shortDescription = getShortDescription(baseFiles);
   let renameCommitMsg =
-    `decaffeinate: Rename ${pluralize(baseFiles.length, 'file')} from .coffee to .js`;
+    `decaffeinate: Rename ${shortDescription} from .coffee to .js`;
   console.log(`Generating the first commit: "${renameCommitMsg}"...`);
   await exec(`git commit -m "${renameCommitMsg}" --author "${gitAuthor}"`);
 
@@ -63,7 +64,7 @@ Re-run with the "check" command for more details.`);
     {runInSeries: true});
 
   let decaffeinateCommitMsg =
-    `decaffeinate: Convert ${pluralize(baseFiles.length, 'file')} to JS`;
+    `decaffeinate: Convert ${shortDescription} to JS`;
   console.log(`Generating the second commit: ${decaffeinateCommitMsg}...`);
   await exec(`git commit -m "${decaffeinateCommitMsg}" --author "${gitAuthor}"`);
 
@@ -115,7 +116,7 @@ Re-run with the "check" command for more details.`);
   await exec(`git add -u`);
 
   let postProcessCommitMsg =
-    `decaffeinate: Run post-processing cleanups on ${pluralize(baseFiles.length, 'file')}`;
+    `decaffeinate: Run post-processing cleanups on ${shortDescription}`;
   console.log(`Generating the third commit: ${postProcessCommitMsg}...`);
   await exec(`git commit -m "${postProcessCommitMsg}" --author "${gitAuthor}"`);
 
@@ -147,6 +148,15 @@ function getBaseFiles(coffeeFiles) {
 async function getGitAuthor() {
   let userEmail = (await exec('git config user.email'))[0];
   return `decaffeinate <${userEmail}>`;
+}
+
+function getShortDescription(baseFiles) {
+  let firstFile = `${path.basename(baseFiles[0])}.coffee`;
+  if (baseFiles.length === 1) {
+    return firstFile;
+  } else {
+    return `${firstFile} and ${pluralize(baseFiles.length - 1, 'other file')}`;
+  }
 }
 
 function makeEslintFixFn(config) {

--- a/test/test.js
+++ b/test/test.js
@@ -170,12 +170,46 @@ describe('convert', () => {
 
       let logStdout = (await exec('git log --pretty="%an <%ae> %s"'))[0];
       assert.equal(logStdout, `\
-decaffeinate <sample@example.com> decaffeinate: Run post-processing cleanups on 2 files
-decaffeinate <sample@example.com> decaffeinate: Convert 2 files to JS
-decaffeinate <sample@example.com> decaffeinate: Rename 2 files from .coffee to .js
+decaffeinate <sample@example.com> decaffeinate: Run post-processing cleanups on A.coffee and 1 other file
+decaffeinate <sample@example.com> decaffeinate: Convert A.coffee and 1 other file to JS
+decaffeinate <sample@example.com> decaffeinate: Rename A.coffee and 1 other file from .coffee to .js
 Sample User <sample@example.com> Initial commit
 `
       );
+    });
+  });
+
+  it('generates a nice commit message when converting just one file', async function() {
+    await runWithTemplateDir('simple-success', async function() {
+      await initGitRepo();
+      let {stdout} = await runCli('convert --file ./A.coffee');
+      assertIncludes(stdout, 'Successfully ran decaffeinate');
+
+      let logStdout = (await exec('git log --pretty="%an <%ae> %s"'))[0];
+      assert.equal(logStdout, `\
+decaffeinate <sample@example.com> decaffeinate: Run post-processing cleanups on A.coffee
+decaffeinate <sample@example.com> decaffeinate: Convert A.coffee to JS
+decaffeinate <sample@example.com> decaffeinate: Rename A.coffee from .coffee to .js
+Sample User <sample@example.com> Initial commit
+`
+      );
+    });
+
+    it('generates a nice commit message when converting three files', async function() {
+      await runWithTemplateDir('file-list', async function () {
+        await initGitRepo();
+        let {stdout} = await runCli('convert --path-file ./files-to-decaffeinate.txt');
+        assertIncludes(stdout, 'Successfully ran decaffeinate');
+
+        let logStdout = (await exec('git log --pretty="%an <%ae> %s"'))[0];
+        assert.equal(logStdout, `\
+decaffeinate <sample@example.com> decaffeinate: Run post-processing cleanups on A.coffee and 2 other files
+decaffeinate <sample@example.com> decaffeinate: Convert A.coffee and 2 other files to JS
+decaffeinate <sample@example.com> decaffeinate: Rename A.coffee and 2 other files from .coffee to .js
+Sample User <sample@example.com> Initial commit
+`
+        );
+      });
     });
   });
 


### PR DESCRIPTION
Instead of just saying the number of files that were converted, we now say the
name of the first file and the number of other files. There's more smart stuff
that could be done like finding a common directory among the files or using the
args that were passed in originally, but I'll leave that until later.