### PR TITLE
feat: add a jscodeshift script to prefer function declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ more information.
 * `jscodeshiftScripts`: an optional array of paths to
   [jscodeshift](https://github.com/facebook/jscodeshift) scripts to run after
   decaffeinate. This is useful to automate any cleanups to convert the output of
-  decaffeinate to code matching your JS style.
+  decaffeinate to code matching your JS style. In addition, you can specify any
+  of the built-in scripts included with this package, currently just
+  `prefer-function-declarations.js`.
 * `fixImportsConfig`: an optional object. If present, a whole-codebase pass will
   be done to fix any incorrect imports involving the converted files. It should
   be an object with up to two fields:

--- a/jscodeshift-scripts/prefer-function-declarations.js
+++ b/jscodeshift-scripts/prefer-function-declarations.js
@@ -1,0 +1,41 @@
+/**
+ * jscodeshift script that converts functions to use function declaration style
+ * in common cases. For example, this code:
+ *
+ * let f = function() {
+ *   return 3;
+ * }
+ *
+ * becomes this code:
+ *
+ * function f() {
+ *   return 3;
+ * }
+ *
+ * Note that this happens whether the declaration is "var", "let", or "const".
+ */
+export default function transformer(file, api) {
+  let j = api.jscodeshift;
+
+  return j(file.source)
+    .find(j.VariableDeclaration)
+    .filter(path => {
+      if (path.node.declarations.length !== 1) {
+        return false;
+      }
+      let [declaration] = path.node.declarations;
+      return declaration.init &&
+        declaration.init.type === 'FunctionExpression' &&
+        declaration.init.id === null;
+    })
+    .replaceWith(path => {
+      let [declaration] = path.node.declarations;
+      return j.functionDeclaration(
+        declaration.id,
+        declaration.init.params,
+        declaration.init.body,
+        declaration.init.generator,
+        declaration.init.expression);
+    })
+    .toSource();
+}

--- a/src/convert.js
+++ b/src/convert.js
@@ -72,8 +72,9 @@ Re-run with the "check" command for more details.`);
 
   if (config.jscodeshiftScripts) {
     for (let scriptPath of config.jscodeshiftScripts) {
-      console.log(`Running jscodeshift script ${scriptPath}...`);
-      await execLive(`${config.jscodeshiftPath} -t ${scriptPath} ${jsFiles.join(' ')}`);
+      let resolvedPath = resolveJscodeshiftScriptPath(scriptPath);
+      console.log(`Running jscodeshift script ${resolvedPath}...`);
+      await execLive(`${config.jscodeshiftPath} -t ${resolvedPath} ${jsFiles.join(' ')}`);
     }
   }
 
@@ -157,6 +158,13 @@ function getShortDescription(baseFiles) {
   } else {
     return `${firstFile} and ${pluralize(baseFiles.length - 1, 'other file')}`;
   }
+}
+
+function resolveJscodeshiftScriptPath(scriptPath) {
+  if (['prefer-function-declarations.js'].includes(scriptPath)) {
+    return path.join(__dirname, `../jscodeshift-scripts-dist/${scriptPath}`);
+  }
+  return scriptPath;
 }
 
 function makeEslintFixFn(config) {

--- a/test/examples/builtin-jscodeshift-script/Func.coffee
+++ b/test/examples/builtin-jscodeshift-script/Func.coffee
@@ -1,0 +1,3 @@
+f = ->
+  console.log 'Hello world'
+  return

--- a/test/examples/builtin-jscodeshift-script/bulk-decaffeinate.config.js
+++ b/test/examples/builtin-jscodeshift-script/bulk-decaffeinate.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  jscodeshiftScripts: [
+    'prefer-function-declarations.js',
+  ],
+};

--- a/test/test.js
+++ b/test/test.js
@@ -231,6 +231,26 @@ let notChanged = 4;
     });
   });
 
+  it('runs built-in jscodeshift scripts', async function() {
+    await runWithTemplateDir('builtin-jscodeshift-script', async function() {
+      await initGitRepo();
+      let {stdout, stderr} = await runCli('convert');
+      assert.equal(stderr, '');
+      assertIncludes(stdout, 'Successfully ran decaffeinate');
+
+      await assertFileContents('./Func.js', `\
+/* eslint-disable
+    no-unused-vars,
+*/
+// TODO: This file was created by bulk-decaffeinate.
+// Fix any style issues and re-enable lint.
+function f() {
+  console.log('Hello world');
+}
+`);
+    });
+  });
+
   it('prepends "eslint-env mocha" when specified', async function() {
     await runWithTemplateDir('mocha-env-test', async function () {
       await initGitRepo();


### PR DESCRIPTION
This is optional, but useful for fixing some eslint issues. This commit also
adds a general mechanism for including built-in jscodeshift scripts, which may
be useful later.