### PR TITLE
fix: don't drop comments in prefer-function-declarations.js

### DIFF
--- a/jscodeshift-scripts/prefer-function-declarations.js
+++ b/jscodeshift-scripts/prefer-function-declarations.js
@@ -30,12 +30,17 @@ export default function transformer(file, api) {
     })
     .replaceWith(path => {
       let [declaration] = path.node.declarations;
-      return j.functionDeclaration(
+      let resultNode = j.functionDeclaration(
         declaration.id,
         declaration.init.params,
         declaration.init.body,
         declaration.init.generator,
         declaration.init.expression);
+      resultNode.comments = [];
+      resultNode.comments.push(...(path.node.comments || []));
+      resultNode.comments.push(...(declaration.comments || []));
+      resultNode.comments.push(...(declaration.init.comments || []));
+      return resultNode;
     })
     .toSource();
 }

--- a/test/examples/builtin-jscodeshift-script/Func.coffee
+++ b/test/examples/builtin-jscodeshift-script/Func.coffee
@@ -1,3 +1,4 @@
+# This is a comment
 f = ->
   console.log 'Hello world'
   return

--- a/test/test.js
+++ b/test/test.js
@@ -244,6 +244,7 @@ let notChanged = 4;
 */
 // TODO: This file was created by bulk-decaffeinate.
 // Fix any style issues and re-enable lint.
+// This is a comment
 function f() {
   console.log('Hello world');
 }


### PR DESCRIPTION
We need to transfer comments from all nodes that aren't kept in the new AST.