### PR TITLE
refactor: use nodegit in the convert command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,9 @@ after_success:
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libstdc++-4.9-dev

--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
   "dependencies": {
     "babel-polyfill": "^6.13.0",
     "commander": "^2.9.0",
+    "fs-promise": "^0.5.0",
     "mz": "^2.4.0",
+    "nodegit": "^0.16.0",
     "opn": "^4.0.2",
     "require-uncached": "^1.0.2"
   }

--- a/src/util/gitTrackedStatus.js
+++ b/src/util/gitTrackedStatus.js
@@ -1,0 +1,9 @@
+import Git from 'nodegit';
+
+/**
+ * Get the status for all tracked files in git.
+ */
+export default async function gitTrackedStatus() {
+  let repo = await Git.Repository.openExt('.', 0, '');
+  return await repo.getStatus({flags: 0});
+}

--- a/src/util/makeCommit.js
+++ b/src/util/makeCommit.js
@@ -1,0 +1,28 @@
+import Git from 'nodegit';
+import path from 'path';
+
+/**
+ * Use nodegit to create a git commit at HEAD.
+ */
+export default async function makeCommit(indexTransform, commitMessage, overrideAuthorName) {
+  let repo = await Git.Repository.openExt('.', 0, '');
+  let index = await repo.refreshIndex();
+  let resolvePath = (filePath) => path.relative(`${repo.path()}/..`, filePath);
+  await indexTransform(index, resolvePath);
+  await index.write();
+  let treeOid = await index.writeTree();
+  let head = await repo.getHeadCommit();
+
+  let signature = repo.defaultSignature();
+  let authorName = overrideAuthorName ? overrideAuthorName : signature.name();
+  let authorSignature = Git.Signature.create(
+    authorName, signature.email(), signature.when().time(), signature.when().offset());
+  await repo.createCommit(
+    'HEAD',
+    authorSignature,
+    signature,
+    commitMessage,
+    treeOid,
+    head ? [head] : null,
+  );
+}

--- a/src/util/makeCommit.js
+++ b/src/util/makeCommit.js
@@ -23,6 +23,5 @@ export default async function makeCommit(indexTransform, commitMessage, override
     signature,
     commitMessage,
     treeOid,
-    head ? [head] : null,
-  );
+    head ? [head] : null);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -165,7 +165,8 @@ describe('convert', () => {
   it('generates git commits converting the files', async function() {
     await runWithTemplateDir('simple-success', async function() {
       await initGitRepo();
-      let {stdout} = await runCli('convert');
+      let {stdout, stderr} = await runCli('convert');
+      assert.equal(stderr, '');
       assertIncludes(stdout, 'Successfully ran decaffeinate');
 
       let logStdout = (await exec('git log --pretty="%an <%ae> %s"'))[0];
@@ -182,7 +183,8 @@ Sample User <sample@example.com> Initial commit
   it('generates a nice commit message when converting just one file', async function() {
     await runWithTemplateDir('simple-success', async function() {
       await initGitRepo();
-      let {stdout} = await runCli('convert --file ./A.coffee');
+      let {stdout, stderr} = await runCli('convert --file ./A.coffee');
+      assert.equal(stderr, '');
       assertIncludes(stdout, 'Successfully ran decaffeinate');
 
       let logStdout = (await exec('git log --pretty="%an <%ae> %s"'))[0];


### PR DESCRIPTION
Also move away from some shell commands in favor of more native move, copy, and
delete functions.

The tests still use shell commands, and could maybe be moved over in the future.