### PR TITLE
feat: add a "land" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ bulk-decaffeinate supports a number of commands:
 * `convert` actually converts the files from CofeeScript to JavaScript.
 * `clean` deletes all .original.coffee files in the current directory or any of
   its subdirectories.
+* `land` packages multiple commits into a merge commit based on an remote branch
+  (`origin/master` by default). Splitting the decaffeinate work into separate
+  commits allows git to properly track file history, but it can create added
+  difficulty after code review is finished, and `land` helps with that. The
+  `land` command does not actually push any commits; it just creates a merge
+  commit that is ready to push after a sanity check.
+  
+  If the `phabricatorAware` option is set, the `land` command does extra work to
+  make sure that every commit has a "Differential Revision" line and that the
+  final merge commit has the commit description.
 
 Here's what `convert` does in more detail:
   1. It does a dry run of decaffeinate on all files to make sure there won't be
@@ -172,6 +182,18 @@ more information.
 * `mochaEnvFilePattern`: an optional regular expression string. If specified,
   all generated JavaScript files with a path matching this pattern have the text
   `/* eslint-env mocha */` added to the start. For example, `"^.*-test.js$"`.
+* `landConfig`: an object with preferences for the `land` command. There are
+  three available options:
+  * `remote`: an optional string with the name of the remote component of the
+    branch to base commits off of. Defaults to `origin`.
+  * `upstreamBranch`: an optional string with the name of the remote branch to
+    base commits off of. Defaults to `master`. For example, if both `remote` and
+    `upstreamBranch` are unspecified, then commits are created based on
+    `origin/master`.
+  * `phabricatorAware`: an optional boolean that's useful if you're using
+    Phabricator for code review. If specified, the generated commits will all
+    have a proper "Differential Revision" line and the final merge commit will
+    be run through `arc amend` to pull in the updated commit message.
 
 ### Configuring paths to external tools
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,6 +5,7 @@ import check from './check';
 import clean from './clean';
 import resolveConfig from './config/resolveConfig';
 import convert from './convert';
+import land from './land';
 import CLIError from './util/CLIError';
 import viewErrors from './viewErrors';
 
@@ -22,6 +23,8 @@ export default function () {
                             for the transition.
     view-errors: Open failures from the most recent run in an online repl.
     clean: Delete all files ending with .original.coffee in the current
+                            working directory or any of its subdirectories.
+    land: Create a merge commit with al
                             working directory or any of its subdirectories.`)
     .action(commandArg => command = commandArg)
     .option('-f, --file [path]',
@@ -60,6 +63,9 @@ async function runCommand(command) {
       await viewErrors();
     } else if (command === 'clean') {
       await clean();
+    } else if (command === 'land') {
+      let config = await resolveConfig(commander, false);
+      await land(config);
     } else {
       commander.outputHelp();
     }

--- a/src/config/getCoffeeFilesFromPathFile.js
+++ b/src/config/getCoffeeFilesFromPathFile.js
@@ -6,7 +6,7 @@ import CLIError from '../util/CLIError';
  * Read a list of .coffee files from a file and return it. Verify that all files
  * end in .coffee and that the files actually exist.
  */
-export default async function getCoffeeFilesFromPathFile(filePath) {
+export default async function getCoffeeFilesFromPathFile(filePath, requireValidFiles) {
   let fileContents = await readFile(filePath);
   let lines = fileContents.toString().split('\n');
   let resultLines = [];
@@ -16,10 +16,18 @@ export default async function getCoffeeFilesFromPathFile(filePath) {
       continue;
     }
     if (!line.endsWith('.coffee')) {
-      throw new CLIError(`The line "${line}" must be a file path ending in .coffee.`);
+      if (requireValidFiles) {
+        throw new CLIError(`The line "${line}" must be a file path ending in .coffee.`);
+      } else {
+        continue;
+      }
     }
     if (!(await exists(line))) {
-      throw new CLIError(`The file "${line}" did not exist.`);
+      if (requireValidFiles) {
+        throw new CLIError(`The file "${line}" did not exist.`);
+      } else {
+        continue;
+      }
     }
     resultLines.push(line);
   }

--- a/src/land.js
+++ b/src/land.js
@@ -1,0 +1,148 @@
+import { exec } from 'mz/child_process';
+import Git from 'nodegit';
+
+import CLIError from './util/CLIError';
+
+/**
+ * The land option "packages" a set of commits into a single merge commit that
+ * can be pushed. Splitting the decaffeinate work up into different commits
+ * allows
+ *
+ * A typical use case is that the merge commit will include 4 commits: the three
+ * auto-generated decaffeinate commits and a follow-up commit to fix lint
+ * errors. The merge commit is a default author name
+ */
+export default async function land(config) {
+  let remote = config.landConfig && config.landConfig.remote;
+  let upstreamBranch = config.landConfig && config.landConfig.upstreamBranch;
+  let phabricatorAware = config.landConfig && config.landConfig.phabricatorAware;  // eslint-disable-line
+  if (!remote) {
+    console.log('No remote was specified. Defaulting to origin.');
+    remote = 'origin';
+  }
+  if (!upstreamBranch) {
+    console.log('No upstreamBranch was specified. Defaulting to master.');
+    upstreamBranch = 'master';
+  }
+  let remoteBranch = `${remote}/${upstreamBranch}`;
+  console.log(`Running fetch for ${remote}.`);
+  let repo = await Git.Repository.openExt('.', 0, '');
+  await fetch(repo, remote);
+
+  let commits = await getCommits(repo);
+  console.log(`Found ${commits.length} commits to use.`);
+
+  let differentialRevisionLine = phabricatorAware ? getDifferentialRevisionLine(commits) : null;
+
+  let remoteRef = await Git.Branch.lookup(repo, remoteBranch, Git.Branch.BRANCH.REMOTE);
+  await repo.checkoutRef(remoteRef);
+  for (let commit of commits) {
+    console.log(`Cherry-picking "${commit.message().split('\n', 1)[0]}"`);
+    await Git.Cherrypick.cherrypick(repo, commit, new Git.CherrypickOptions());
+    let index = await repo.refreshIndex();
+    if (index.hasConflicts()) {
+      throw new CLIError(`\
+The cherry pick had conflicts.
+Please rebase your changes and retry "bulk-decaffeinate land"`);
+    }
+    let message = commit.message();
+    if (phabricatorAware) {
+      if (!message.includes('Differential Revision')) {
+        message += `\n\n${differentialRevisionLine}`;
+      }
+    }
+    await repo.createCommitOnHead([], commit.author(), repo.defaultSignature(), message);
+  }
+
+  console.log(`Creating merge commit on ${remoteBranch}`);
+  let cherryPickHeadCommit = await repo.getHeadCommit();
+  let cherryPickHead = await Git.AnnotatedCommit.fromRef(repo, await repo.head());
+  await repo.checkoutRef(remoteRef);
+  let mergeMessage = `Merge decaffeinate changes into ${remoteBranch}`;
+  if (phabricatorAware) {
+    mergeMessage += `\n\n${differentialRevisionLine}`;
+  }
+  await createMergeCommit(repo, cherryPickHead, cherryPickHeadCommit, mergeMessage);
+  if (phabricatorAware) {
+    console.log('Pulling commit message from Phabricator.');
+    await exec('arc amend');
+  }
+  console.log('');
+  console.log('Done. Please verify that the git history looks right.');
+  console.log('You can push your changes with a command like this:');
+  console.log(`git push ${remote} HEAD:${upstreamBranch}`);
+  console.log('If you get a conflict, you should re-run "bulk-decaffeinate land".');
+}
+
+async function fetch(repo, remote) {
+  await repo.fetch(remote, {
+    callbacks: {
+      credentials(url, userName) {
+        return Git.Cred.sshKeyFromAgent(userName);
+      },
+    },
+  });
+}
+
+async function getCommits(repo) {
+  let commit = await repo.getHeadCommit();
+  let commits = [];
+  let i = 0;
+  let hasSeenDecaffeinateCommit = false;
+  for (i = 0; i < 20; i++) {
+    let isDecaffeinateCommit = commit.author().name() === 'decaffeinate';
+    if (hasSeenDecaffeinateCommit && !isDecaffeinateCommit) {
+      break;
+    }
+    if (!hasSeenDecaffeinateCommit && isDecaffeinateCommit) {
+      hasSeenDecaffeinateCommit = true;
+    }
+    commits.unshift(commit);
+    commit = await commit.parent(0);
+  }
+  if (i >= 20) {
+    throw new CLIError(`\
+Searched 20 commits without finding a set of commits to use. Make sure you have
+commits with the "decaffeinate" author in your recent git history, and that the
+first of those commits is the first commit that you would like to land.`);
+  }
+  return commits;
+}
+
+function getDifferentialRevisionLine(commits) {
+  let resultLine = null;
+  for (let commit of commits) {
+    for (let line of commit.message().split('\n')) {
+      if (line.startsWith('Differential Revision')) {
+        if (resultLine === null || resultLine === line) {
+          resultLine = line;
+        } else {
+          throw new CLIError(`\
+Found multiple different "Differential Revision" lines in the matched commits.
+Please set your git HEAD so that only one Phabricator code review is included.`);
+        }
+      }
+    }
+  }
+  if (resultLine === null) {
+    throw new CLIError(`
+Expected to find a "Differential Revision" line in at least one commit.`);
+  }
+  return resultLine;
+}
+
+async function createMergeCommit(repo, cherryPickHead, cherryPickHeadCommit, mergeMessage) {
+  await Git.Merge.merge(repo, cherryPickHead);
+  repo.stateCleanup();
+  let index = await repo.refreshIndex();
+  await index.write();
+  let treeOid = await index.writeTree();
+  await repo.createCommit(
+    'HEAD',
+    repo.defaultSignature(),
+    repo.defaultSignature(),
+    mergeMessage,
+    treeOid,
+    [await repo.getHeadCommit(), cherryPickHeadCommit]
+  );
+}


### PR DESCRIPTION
This is especially useful for Phabricator workflows where you ideally want to
update every commit message to point to the code review. But it's also useful in
general for making it a little easier to push a change that includes independent
commits.

Unfortunately, tests for this command are hard because it runs `fetch` and
`arc`, so I'll punt on tests for now.