### PR TITLE
fix: pre-process JS files to determine which are eligible for fix-imports

### DIFF
--- a/src/util/CLIError.js
+++ b/src/util/CLIError.js
@@ -13,6 +13,9 @@ export default class CLIError extends Error {
   }
 
   static formatError(e) {
+    if (!e) {
+      return e;
+    }
     if (e.message.startsWith(PREFIX)) {
       return e.message.substring(PREFIX.length);
     } else {


### PR DESCRIPTION
This is a bit faster than doing a full JS parse on each file, and is also nice
in that it lets us know which files we need to add in git.

This also fixes a race condition where the nodegit "status" command wasn't
returning all files that should be committed.