### PR TITLE
fix: properly ignore file validity check for "land" command

### DIFF
--- a/src/config/resolveConfig.js
+++ b/src/config/resolveConfig.js
@@ -27,7 +27,9 @@ export default async function resolveConfig(commander, requireValidFiles = true)
   }
   config = Object.assign(config, getCLIParamsConfig(commander));
   let filesToProcess = await resolveFilesToProcess(config, requireValidFiles);
-  await validateFilesToProcess(filesToProcess);
+  if (requireValidFiles) {
+    await validateFilesToProcess(filesToProcess);
+  }
   return {
     filesToProcess,
     fixImportsConfig: config.fixImportsConfig,


### PR DESCRIPTION
We already ignored one validity check, but not another. This should make it
possible to run "land" with JS files already existing for the configuration.