### PR TITLE
fix: reduce the size of the jscodeshift command for fix-imports

### DIFF
--- a/jscodeshift-scripts/fix-imports.js
+++ b/jscodeshift-scripts/fix-imports.js
@@ -20,9 +20,14 @@
  */
 import { existsSync, readFileSync } from 'fs';
 import path from 'path';
+import zlib from 'zlib';
 
 export default function (fileInfo, api, options) {
-  let decodedOptions = JSON.parse(new Buffer(options['encoded-options'], 'base64'));
+  let decodedOptions = JSON.parse(
+    zlib.inflateSync(
+      new Buffer(options['encoded-options'], 'base64')
+    ).toString()
+  );
   let {convertedFiles, absoluteImportPaths} = decodedOptions;
   let j = api.jscodeshift;
   let thisFilePath = path.resolve(fileInfo.path);


### PR DESCRIPTION
On Mac, there's a default system limit of 256K for any shell commands. When we
invoke jscodeshift, we explicitly specify every path to transform and we also
include a base64ed JSON string with that same array of absolute paths. When
running bulk-decaffeinate on my entire codebase, this was generating a command
of length about 280K, so it was crashing.

To address this, I reduced the size in two ways:
* I use relative instead of absolute paths for the list of files sent to
  jscodeshift. This reduced the length of that part by about a factor of 2 for
  me.
* I gzip-compress the JSON string and decompress on the other end. This reduced
  the length of that part by about a factor of 10.

Overall this reduced the arg size by a factor of about 2.5, down to 100K.