### PR TITLE
fix: increase the parallelism from 4 to 8

### DIFF
--- a/src/runner/runWithProgressBar.js
+++ b/src/runner/runWithProgressBar.js
@@ -1,7 +1,7 @@
 import runInParallel from './runInParallel';
 import pluralize from '../util/pluralize';
 
-const NUM_CONCURRENT_PROCESSES = 4;
+const NUM_CONCURRENT_PROCESSES = 8;
 
 /**
  * Run the given command in parallel, showing a progress bar of results.


### PR DESCRIPTION
On my 4-core laptop, this reduced the time to run `check` on my codebase from
about 15 minutes to about 10 minutes.