### PR TITLE
feat: add a config option for specifying decaffeinate args

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ more information.
 
 ### Other configuration
 
+* `decaffeinateArgs`: an optional array of additional command-line arguments to
+  pass to decaffeinate. For example, `['--keep-commonjs']` sets the preference
+  to keep `require` and `module.exports` rather than converting them to `import`
+  and `export`.
 * `jscodeshiftScripts`: an optional array of paths to
   [jscodeshift](https://github.com/facebook/jscodeshift) scripts to run after
   decaffeinate. This is useful to automate any cleanups to convert the output of

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "babel-preset-es2015": "^6.13.0",
     "babel-register": "^6.11.6",
     "babelrc-rollup": "^3.0.0",
-    "decaffeinate": "^2.22.1",
+    "decaffeinate": "^2.31.0",
     "eslint": "^3.2.2",
     "eslint-plugin-babel": "^4.0.0",
     "jscodeshift": "^0.3.28",

--- a/src/check.js
+++ b/src/check.js
@@ -5,10 +5,10 @@ import runWithProgressBar from './runner/runWithProgressBar';
 import pluralize from './util/pluralize';
 
 export default async function check(config) {
-  let {filesToProcess, decaffeinatePath} = config;
+  let {filesToProcess, decaffeinateArgs = [], decaffeinatePath} = config;
   let decaffeinateResults = await runWithProgressBar(
     `Doing a dry run of decaffeinate on ${pluralize(filesToProcess.length, 'file')}...`,
-    filesToProcess, makeCLIFn(path => `${decaffeinatePath} < ${path}`));
+    filesToProcess, makeCLIFn(path => `${decaffeinatePath} ${decaffeinateArgs.join(' ')} < ${path}`));
   await printResults(decaffeinateResults);
 }
 

--- a/src/config/resolveConfig.js
+++ b/src/config/resolveConfig.js
@@ -31,6 +31,7 @@ export default async function resolveConfig(commander, requireValidFiles = true)
     await validateFilesToProcess(filesToProcess);
   }
   return {
+    decaffeinateArgs: config.decaffeinateArgs,
     filesToProcess,
     fixImportsConfig: config.fixImportsConfig,
     jscodeshiftScripts: config.jscodeshiftScripts,

--- a/src/convert.js
+++ b/src/convert.js
@@ -17,10 +17,12 @@ export default async function convert(config) {
 
   let coffeeFiles = config.filesToProcess;
   let baseFiles = getBaseFiles(coffeeFiles);
+  let {decaffeinateArgs = [], decaffeinatePath} = config;
 
   let decaffeinateResults = await runWithProgressBar(
     'Verifying that decaffeinate can successfully convert these files...',
-    coffeeFiles, makeCLIFn(path => `${config.decaffeinatePath} < ${path}`));
+    coffeeFiles, makeCLIFn(path =>
+      `${decaffeinatePath} ${decaffeinateArgs.join(' ')} < ${path}`));
   if (decaffeinateResults.filter(r => r.error !== null).length > 0) {
     throw new CLIError(`\
 Some files could not be convered with decaffeinate.
@@ -65,7 +67,7 @@ Re-run with the "check" command for more details.`);
   await runWithProgressBar(
     'Running decaffeinate on all files...',
     coffeeFiles,
-    makeCLIFn(path => `${config.decaffeinatePath} ${path}`)
+    makeCLIFn(path => `${decaffeinatePath} ${decaffeinateArgs.join(' ')} ${path}`)
   );
 
   await runAsync(

--- a/test/examples/decaffeinate-args-test/A.coffee
+++ b/test/examples/decaffeinate-args-test/A.coffee
@@ -1,0 +1,2 @@
+a = require 'b'
+module.exports = c

--- a/test/examples/decaffeinate-args-test/bulk-decaffeinate.config.js
+++ b/test/examples/decaffeinate-args-test/bulk-decaffeinate.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  decaffeinateArgs: ['--keep-commonjs'],
+};


### PR DESCRIPTION
Unfortunately, invalid args fail pretty poorly at the moment, but I think that
can be fixed on the decaffeinate side.

Also clean up some test code to better assert success.