### PR TITLE
fix: don't modify imports when they point at a module with no exports

### DIFF
--- a/jscodeshift-scripts/fix-imports.js
+++ b/jscodeshift-scripts/fix-imports.js
@@ -80,6 +80,11 @@ export default function (fileInfo, api, options) {
       return path.node;
     }
     let exportsInfo = getExportsInformation(resolvedPath);
+    // If we didn't see anything on the other side, it might not even be a JS
+    // module, so just leave this import as-is.
+    if (!exportsInfo.hasDefaultExport && exportsInfo.namedExports.length === 0) {
+      return path.node;
+    }
     let specifierIndex = getSpecifierIndex(path);
     let memberAccesses = findAllMemberAccesses(specifierIndex);
     let importManifest = getImportManifest(exportsInfo, memberAccesses);

--- a/test/examples/fix-imports-import-commonjs/ImportThree.coffee
+++ b/test/examples/fix-imports-import-commonjs/ImportThree.coffee
@@ -1,0 +1,2 @@
+three = require './three'
+console.log(three);

--- a/test/examples/fix-imports-import-commonjs/ImportThree.js.expected
+++ b/test/examples/fix-imports-import-commonjs/ImportThree.js.expected
@@ -1,0 +1,4 @@
+// TODO: This file was created by bulk-decaffeinate.
+// Sanity-check the conversion and remove this comment.
+import three from './three';
+console.log(three);

--- a/test/examples/fix-imports-import-commonjs/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-import-commonjs/bulk-decaffeinate.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  fixImportsConfig: {
+    searchPath: '.',
+  },
+};

--- a/test/examples/fix-imports-import-commonjs/three.js
+++ b/test/examples/fix-imports-import-commonjs/three.js
@@ -1,0 +1,1 @@
+module.exports = 3;

--- a/test/test.js
+++ b/test/test.js
@@ -421,4 +421,8 @@ describe('fix-imports', () => {
   it('only does relative path resolution when an import is relative style', async function() {
     await runFixImportsTest('fix-imports-non-relative-path');
   });
+
+  it('makes no changes when the other file is not a JS module', async function() {
+    await runFixImportsTest('fix-imports-import-commonjs');
+  });
 });


### PR DESCRIPTION
When an import statement point at a file without any exports at all (e.g. a
commonjs module), the fix-imports script was viewing it as a file with only
named exports (which is vacuously true) and changing the import style to
`import *`. This broke cases where a commonjs module exported anything other
than an object.