### PR TITLE
fix: increase buffer size to 5MB when running CLI commands

### DIFF
--- a/src/runner/makeCLIFn.js
+++ b/src/runner/makeCLIFn.js
@@ -3,7 +3,7 @@ import { exec } from 'mz/child_process';
 export default function makeCLIFn(commandByPath) {
   return async function(path) {
     try {
-      await exec(commandByPath(path));
+      await exec(commandByPath(path), {maxBuffer: 5 * 1024 * 1024});
       return {path, error: null};
     } catch (e) {
       return {path, error: e.message};


### PR DESCRIPTION
Some decaffeinate runs had more than 200KB of stdout, which gave an error
message.