### PR TITLE
feat: prefer function declarations for arrow functions too

### DIFF
--- a/test/examples/builtin-jscodeshift-script/Func.coffee
+++ b/test/examples/builtin-jscodeshift-script/Func.coffee
@@ -3,3 +3,6 @@ a = require('./A.coffee')
 f = ->
   console.log 'Hello world'
   return
+
+arrow = ->
+  3 + 4

--- a/test/test.js
+++ b/test/test.js
@@ -242,7 +242,7 @@ let notChanged = 4;
     });
   });
 
-  it('runs built-in jscodeshift scripts', async function() {
+  it.only('runs built-in jscodeshift scripts', async function() {
     await runWithTemplateDir('builtin-jscodeshift-script', async function() {
       await initGitRepo();
       await runCliExpectSuccess('convert');
@@ -257,6 +257,10 @@ import a from './A';
 // This is a comment
 function f() {
   console.log('Hello world');
+}
+
+function arrow() {
+  return 3 + 4;
 }
 `);
     });

--- a/test/test.js
+++ b/test/test.js
@@ -242,7 +242,7 @@ let notChanged = 4;
     });
   });
 
-  it.only('runs built-in jscodeshift scripts', async function() {
+  it('runs built-in jscodeshift scripts', async function() {
     await runWithTemplateDir('builtin-jscodeshift-script', async function() {
       await initGitRepo();
       await runCliExpectSuccess('convert');


### PR DESCRIPTION
The esnext stage can turn some functions into arrow functions. This transform misses those. To make it safer, arrow functions will only be transformed if it is part of a top-level variable declaration.