### PR TITLE
fix: work around jscodeshift bug when converting arrow functions with comments

### DIFF
--- a/test/examples/builtin-jscodeshift-script/Func.coffee
+++ b/test/examples/builtin-jscodeshift-script/Func.coffee
@@ -6,3 +6,7 @@ f = ->
 
 arrow = ->
   3 + 4
+
+arrowWithComment = ->
+  # This is a comment
+  5

--- a/test/test.js
+++ b/test/test.js
@@ -262,6 +262,11 @@ function f() {
 function arrow() {
   return 3 + 4;
 }
+
+function arrowWithComment() {
+  // This is a comment
+  return 5;
+}
 `);
     });
   });


### PR DESCRIPTION
Previously it would change an arrow function returning 5 into this code:

```js
function arrowWithComment() {
  return // This is a comment
  5;
}
```

which has a semicolon inserted after the `return`. This looks like a bug in
jscodeshift/recast, but the quick fix is to reposition any comments onto the
return statement rather than the returned expression.